### PR TITLE
refactor: local.properties대신 secret.properties 사용하도록 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /captures
 .cxx
 .idea/
+secret.properties
 
 # Created by https://www.toptal.com/developers/gitignore/api/java,kotlin,androidstudio
 # Edit at https://www.toptal.com/developers/gitignore?templates=java,kotlin,androidstudio

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.google.gms.google.services) apply false
+    alias(libs.plugins.secrets.gradle.plugin) apply false
 }

--- a/carefull/build.gradle.kts
+++ b/carefull/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.util.Properties
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -7,16 +5,8 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.google.gms.google.services)
+    alias(libs.plugins.secrets.gradle.plugin)
 }
-
-val localProperties = Properties()
-val localPropertiesFile = rootProject.file("local.properties")
-if (localPropertiesFile.exists()) {
-    localProperties.load(localPropertiesFile.inputStream())
-}
-
-val naverMapClientId = localProperties.getProperty("NAVER_MAP_CLIENT_ID")
-
 
 android {
     namespace = "com.cases.carefull"
@@ -30,9 +20,6 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-
-//        manifestPlaceholders["NAVER_MAP_CLIENT_ID"] = naverMapClientId
-
     }
 
     buildTypes {
@@ -50,8 +37,14 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
+
+secrets {
+    propertiesFileName = "secret.properties"
+}
+
 kotlin {
     jvmToolchain(21)
 }
@@ -83,10 +76,6 @@ dependencies {
     implementation(libs.firebase.firestore.ktx)
 
     implementation(libs.kotlin.reflect)
-
-    // 네이버 지도
-    implementation("com.naver.maps:map-sdk:3.22.0")
-    implementation(libs.play.services.maps)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/carefull/src/main/AndroidManifest.xml
+++ b/carefull/src/main/AndroidManifest.xml
@@ -13,9 +13,9 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Carefull">
 
-<!--        <meta-data-->
-<!--            android:name="com.naver.maps.map.NCP_KEY_ID"-->
-<!--            android:value="${NAVER_MAP_CLIENT_ID}" />-->
+        <meta-data
+            android:name="com.naver.maps.map.NCP_KEY_ID"
+            android:value="${NAVER_MAP_CLIENT_ID}" />
 
         <activity
             android:name=".MainActivity"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,9 @@ kotlinxSerializationJson = "1.9.0"
 
 coilCompose = "2.7.0"
 
+# serect
+secretsGradlePlugin = "2.0.1"
+
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
@@ -77,6 +80,7 @@ jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrai
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinSerialization" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin"}
 google-gms-google-services = { id = "com.google.gms.google-services", version.ref = "googleGmsServices" }
+secrets-gradle-plugin = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin",  version.ref = "secretsGradlePlugin" }
 
 [bundles]
 compose-libraries = [


### PR DESCRIPTION
## 📝 작업 내용 
- secret.properties를 사용하기 위한 환경 설정을 하였습니다.
- local.properties 사용하기 위한 설정들을 삭제하였습니다.

## 📑 상세 설명 
- secret.properties 파일 생성
- toml, gradle, AndriodManifest 추가
- .gitignore에 secret.properties 추가