### PR TITLE
refactor: 약 검색 및 상세정보 코드 수정, uistate 적용

### DIFF
--- a/carefull/src/main/java/com/cases/carefull/common/MainViewModel.kt
+++ b/carefull/src/main/java/com/cases/carefull/common/MainViewModel.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.LocalHospital
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.lifecycle.ViewModel
+import com.cases.carefull.BuildConfig
 import com.cases.carefull.domain.model.NavType
 import com.cases.carefull.domain.model.ScreenConfig
 import com.cases.carefull.features.carefullcommon.model.MainUiState
@@ -26,6 +27,7 @@ import kotlinx.coroutines.flow.update
 
 
 class MainViewModel(private val repository: NavigationRepository) : ViewModel() {
+
 	private val _uiState = MutableStateFlow(MainUiState())
 	val uiState: StateFlow<MainUiState> = _uiState
 	

--- a/carefull/src/main/java/com/cases/carefull/di/AppContainer.kt
+++ b/carefull/src/main/java/com/cases/carefull/di/AppContainer.kt
@@ -1,33 +1,45 @@
 package com.cases.carefull.di
 
+import androidx.lifecycle.ViewModelProvider
+import com.cases.carefull.BuildConfig
 import com.cases.carefull.data.repository.MedicineRepositoryImpl
 import com.cases.carefull.domain.repository.MedicineRepository
-import com.cases.carefull.features.carefullcontents.diagnosis.medicine.RetrofitInstance
+import com.cases.carefull.data.network.RetrofitInstance
 import com.cases.carefull.domain.usecase.MedicineSearchUseCase
 import com.cases.carefull.features.carefullcommon.components.NavigationRepositoryImpl
 import com.cases.carefull.features.carefullcommon.model.NavigationRepository
 
 interface AppContainer {
+    val navigationRepository: NavigationRepository
     val medicineRepository: MedicineRepository
     val medicineSearchUseCase: MedicineSearchUseCase
-    val navigationRepository: NavigationRepository
+    val medicineViewModelFactory: ViewModelProvider.Factory
 }
 
 class DefaultAppContainer : AppContainer {
 
-    private val apiService by lazy {
+    override val navigationRepository: NavigationRepository by lazy {
+        NavigationRepositoryImpl()
+    }
+
+    private val medicineApiService by lazy {
         RetrofitInstance.medicineApi
     }
 
     override val medicineRepository: MedicineRepository by lazy {
-        MedicineRepositoryImpl(apiService)
+        MedicineRepositoryImpl(medicineApiService)
     }
 
     override val medicineSearchUseCase: MedicineSearchUseCase by lazy {
         MedicineSearchUseCase(medicineRepository)
     }
 
-    override val navigationRepository: NavigationRepository by lazy {
-        NavigationRepositoryImpl()
+    override val medicineViewModelFactory: ViewModelProvider.Factory by lazy {
+        MainViewModelFactory(
+            navigationRepository = navigationRepository, // navigationRepository도 AppContainer에 있다고 가정
+            medicineSearchUseCase = medicineSearchUseCase, // AppContainer가 가진 UseCase 전달
+            // AppContainer가 BuildConfig에 직접 접근하여 API 키를 가져옵니다.
+            medicineApiKey = BuildConfig.medicine_api_key
+        )
     }
 }

--- a/carefull/src/main/java/com/cases/carefull/di/ViewModelFactory.kt
+++ b/carefull/src/main/java/com/cases/carefull/di/ViewModelFactory.kt
@@ -10,7 +10,8 @@ import com.cases.carefull.features.carefullcontents.diagnosis.medicine.MedicineV
 
 class MainViewModelFactory(
 	private val navigationRepository: NavigationRepository,
-	private val medicineRepository: MedicineRepository
+	private val medicineSearchUseCase: MedicineSearchUseCase,
+	private val medicineApiKey: String
 ) : ViewModelProvider.Factory {
 	override fun <T : ViewModel> create(modelClass: Class<T>): T {
 		if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
@@ -19,7 +20,7 @@ class MainViewModelFactory(
 		}
 		else if (modelClass.isAssignableFrom(MedicineViewModel::class.java)) {
 			@Suppress("UNCHECKED_CAST")
-			return MedicineViewModel(medicineRepository) as T
+			return MedicineViewModel(medicineSearchUseCase = medicineSearchUseCase, medicineApiKey = medicineApiKey) as T
 		}
 		throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
 	}

--- a/carefull/src/main/java/com/cases/carefull/navigation/MainNavigation.kt
+++ b/carefull/src/main/java/com/cases/carefull/navigation/MainNavigation.kt
@@ -23,6 +23,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.cases.carefull.BuildConfig
 import com.cases.carefull.Splash
 import com.cases.carefull.common.CarefullApplication
 import com.cases.carefull.common.MainViewModel
@@ -70,13 +71,19 @@ import kotlinx.coroutines.launch
 @Composable
 fun MainNavigation() {
     val application = LocalContext.current.applicationContext as CarefullApplication
+
     val container = application.container
+
     val navigationRepository = container.navigationRepository
-    val medicineRepository = container.medicineRepository
+    val medicineSearchUseCase = container.medicineSearchUseCase
+    val medicineApiKey = BuildConfig.medicine_api_key
+
     val mainViewModelFactory = MainViewModelFactory(
         navigationRepository = navigationRepository,
-        medicineRepository = medicineRepository
+        medicineSearchUseCase = medicineSearchUseCase,
+        medicineApiKey = medicineApiKey
     )
+
     val viewModel: MainViewModel = viewModel(factory = mainViewModelFactory)
     val uiState by viewModel.uiState.collectAsState()
     val foodRepository = remember { DietRepositoryImpl() }
@@ -246,11 +253,9 @@ fun MainNavigation() {
 
                 MedicineSearchScreen(
                     viewModel = medicineViewModel,
+                    medicineApiKey = medicineApiKey,
                     onNavigateToMedicineInfo = {
-                        Log.d("NAVIGATION_DEBUG", "onNavigateToMedicineDetail 호출됨! 화면 전환을 시도합니다.")
-                        val destination = DiagnosisRoute.MedicineDetailScreen
-                        Log.d("NAVIGATION_DEBUG", "이동할 목적지: $destination")
-                        navController.navigate(destination)
+                        navController.navigate(DiagnosisRoute.MedicineDetailScreen)
 //						navController.navigate(DiagnosisRoute.MedicineDetailScreen)
                     }
                 )

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -49,7 +49,8 @@ dependencies {
     // firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.firestore.ktx)
-
+    // 로그 확인용
+    implementation(libs.logging.interceptor)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/data/src/main/java/com/cases/carefull/data/mapper/MedicineMapper.kt
+++ b/data/src/main/java/com/cases/carefull/data/mapper/MedicineMapper.kt
@@ -1,6 +1,6 @@
 package com.cases.carefull.data.mapper
 
-import com.cases.carefull.data.dto.MedicineItemDto
+import com.cases.carefull.data.model.MedicineItemDto
 import com.cases.carefull.domain.model.MedicineItem
 
 fun MedicineItemDto.toDomain(): MedicineItem {

--- a/data/src/main/java/com/cases/carefull/data/model/MedicineItemDto.kt
+++ b/data/src/main/java/com/cases/carefull/data/model/MedicineItemDto.kt
@@ -1,4 +1,4 @@
-package com.cases.carefull.data.dto
+package com.cases.carefull.data.model
 
 import com.google.gson.annotations.SerializedName
 

--- a/data/src/main/java/com/cases/carefull/data/model/MedicineResponse.kt
+++ b/data/src/main/java/com/cases/carefull/data/model/MedicineResponse.kt
@@ -1,7 +1,5 @@
-package com.cases.carefull.data.network
+package com.cases.carefull.data.model
 
-import com.cases.carefull.data.dto.MedicineItemDto
-import com.cases.carefull.domain.model.MedicineItem
 import com.google.gson.annotations.SerializedName
 
 data class MedicineResponse(

--- a/data/src/main/java/com/cases/carefull/data/network/MedicineApiService.kt
+++ b/data/src/main/java/com/cases/carefull/data/network/MedicineApiService.kt
@@ -1,5 +1,6 @@
 package com.cases.carefull.data.network
 
+import com.cases.carefull.data.model.MedicineResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 

--- a/data/src/main/java/com/cases/carefull/data/network/RetrofitInstance.kt
+++ b/data/src/main/java/com/cases/carefull/data/network/RetrofitInstance.kt
@@ -1,15 +1,25 @@
-package com.cases.carefull.features.carefullcontents.diagnosis.medicine
+package com.cases.carefull.data.network
 
-import com.cases.carefull.data.network.MedicineApiService
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitInstance {
     private const val BASE_URL = "http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/"
 
-    private val retrofit by lazy {
+    private val loggingInterceptor = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.BODY
+    }
+
+    private val okHttpClient = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .build()
+
+    private val retrofit: Retrofit by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)
+            .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }

--- a/data/src/main/java/com/cases/carefull/data/repository/MedicineRepositoryImpl.kt
+++ b/data/src/main/java/com/cases/carefull/data/repository/MedicineRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.cases.carefull.data.repository
 
 import android.util.Log
-import com.cases.carefull.data.dto.MedicineItemDto
+import com.cases.carefull.data.model.MedicineItemDto
 import com.cases.carefull.data.network.MedicineApiService
 import com.cases.carefull.domain.model.MedicineItem
 import com.cases.carefull.data.mapper.toDomain
@@ -12,17 +12,15 @@ class MedicineRepositoryImpl(
     private val apiService: MedicineApiService
 ) : MedicineRepository {
 
-    private val serviceKey
-    
-    override suspend fun searchMedicines(query: String): Result<List<MedicineItem>> {
+
+    override suspend fun searchMedicines(medicineApiKey: String, query: String): Result<List<MedicineItem>> {
         if (query.isBlank()) {
             return Result.success(emptyList())
         }
         Log.d("API_TEST", "Repository: API 호출 시도, query = $query")
         return try {
             val response = apiService.getMedicineList(
-                serviceKey = serviceKey,
-//                serviceKey = BuildConfig.medicine_api_key,
+                serviceKey = medicineApiKey,
                 itemName = query
             )
             Log.d("API_TEST", "Repository: API 호출 시도, ${response.header.resultCode}")

--- a/domain/src/main/java/com/cases/carefull/domain/repository/MedicineRepository.kt
+++ b/domain/src/main/java/com/cases/carefull/domain/repository/MedicineRepository.kt
@@ -3,5 +3,5 @@ package com.cases.carefull.domain.repository
 import com.cases.carefull.domain.model.MedicineItem
 
 interface MedicineRepository {
-    suspend fun searchMedicines(query: String): Result<List<MedicineItem>>
+    suspend fun searchMedicines(medicineApiKey: String, query: String): Result<List<MedicineItem>> // 파라미터로 api 키 받기
 }

--- a/domain/src/main/java/com/cases/carefull/domain/usecase/MedicineSearchUseCase.kt
+++ b/domain/src/main/java/com/cases/carefull/domain/usecase/MedicineSearchUseCase.kt
@@ -4,5 +4,5 @@ import com.cases.carefull.domain.repository.MedicineRepository
 
 
 class MedicineSearchUseCase(private val repository: MedicineRepository) {
-    suspend operator fun invoke(query: String) = repository.searchMedicines(query)
+    suspend operator fun invoke(medicineApiKey: String, query: String) = repository.searchMedicines(medicineApiKey, query)
 }

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/UiState.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/UiState.kt
@@ -1,0 +1,10 @@
+package com.cases.carefull.features.carefullcontents
+
+sealed class UiState<out T : Any?> {
+
+    object Loading : UiState<Nothing>()
+
+    data class Success<out T : Any>(val data: T) : UiState<T>()
+
+    data class Error(val errorMessage: String) : UiState<Nothing>()
+}

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/medicine/MedicineSearchScreen.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/medicine/MedicineSearchScreen.kt
@@ -3,6 +3,7 @@ package com.cases.carefull.features.carefullcontents.diagnosis.medicine
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -21,6 +22,7 @@ import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -39,16 +41,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cases.carefull.domain.model.MedicineItem
+import com.cases.carefull.features.carefullcontents.UiState
 
 @Composable
 fun MedicineSearchScreen(
     viewModel: MedicineViewModel,
+    medicineApiKey: String,
     onNavigateToMedicineInfo: () -> Unit
 ) {
-    var query by remember { mutableStateOf("") }
-    val searchResults by viewModel.medicineList.collectAsState()
-    val recentSearches by viewModel.recentSearches.collectAsState()
+    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
+    val searchResults by viewModel.searchResultState.collectAsStateWithLifecycle()
+    val recentSearches by viewModel.recentSearches.collectAsStateWithLifecycle()
 
     Scaffold { innerPadding ->
         Column(
@@ -74,10 +79,9 @@ fun MedicineSearchScreen(
                 Spacer(modifier = Modifier.width(8.dp))
 
                 TextField(
-                    value = query,
-                    onValueChange = {
-                        query = it
-                        viewModel.searchMedicine(it)
+                    value = searchQuery,
+                    onValueChange = {newQuery ->
+                        viewModel.onQueryChange(newQuery, medicineApiKey)
                     },
                     placeholder = { Text("약 이름을 입력하세요", color = Color.Gray) },
                     singleLine = true,
@@ -94,9 +98,7 @@ fun MedicineSearchScreen(
                 )
                 IconButton(
                     onClick = {
-                        if (query.isNotBlank()) {
-                            viewModel.addRecentSearch(query)
-                        }
+                        viewModel.addRecentSearch(searchQuery)
                     }) {
                     Icon(
                         imageVector = Icons.Default.Search,
@@ -108,25 +110,37 @@ fun MedicineSearchScreen(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            if (query.isEmpty()) {
+            if (searchQuery.isEmpty()) {
                 RecentSearchSection(
                     recentSearches = recentSearches,
                     onSearch = { searchTerm ->
-                        query = searchTerm
-                        viewModel.searchMedicine(searchTerm)
+                        viewModel.onQueryChange(searchTerm, medicineApiKey)
                     },
-                    onRemove = { searchTerm -> viewModel.removeRecentSearch(searchTerm) },
-                    onClearAll = { viewModel.clearRecentSearches() }
+                    onRemove = viewModel::removeRecentSearch,
+                    onClearAll = viewModel::clearRecentSearches
                 )
             } else {
-                SearchResultSection(
-                    searchResults = searchResults,
-                    onItemClick = { medicineItem ->
-                        viewModel.addRecentSearch(medicineItem.itemName ?: "")
-                        viewModel.setSelectedItem(medicineItem)
-                        onNavigateToMedicineInfo()
+                when (val state = searchResults) {
+                    is UiState.Loading -> {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator()
+                        }
                     }
-                )
+                    is UiState.Success -> {
+                        SearchResultSection(
+                            searchResults = state.data,
+                            onItemClick = { medicineItem ->
+                                viewModel.setSelectedItem(medicineItem)
+                                onNavigateToMedicineInfo()
+                            }
+                        )
+                    }
+                    is UiState.Error -> {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            Text("에러가 발생했습니다: ${state.errorMessage}", color = Color.Red)
+                        }
+                    }
+                }
             }
         }
     }
@@ -196,7 +210,8 @@ private fun SearchResultSection(
                         .fillMaxWidth()
                         .padding(vertical = 4.dp)
                         .clickable {
-                            onItemClick(item) },
+                            onItemClick(item)
+                        },
                     elevation = CardDefaults.cardElevation(2.dp)
                 ) {
                     Column(Modifier.padding(16.dp)) {

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/medicine/MedicineViewModel.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/medicine/MedicineViewModel.kt
@@ -5,16 +5,20 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cases.carefull.domain.model.MedicineItem
 import com.cases.carefull.domain.repository.MedicineRepository
+import com.cases.carefull.domain.usecase.MedicineSearchUseCase
+import com.cases.carefull.features.carefullcontents.UiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class MedicineViewModel(
-    private val repository: MedicineRepository
+    private val medicineSearchUseCase: MedicineSearchUseCase,
+    private val medicineApiKey: String
 ) : ViewModel() {
 
-    private val _medicineList = MutableStateFlow<List<MedicineItem>>(emptyList())
-    val medicineList = _medicineList.asStateFlow()
+    private val _searchResultState = MutableStateFlow<UiState<List<MedicineItem>>>(UiState.Success(emptyList()))
+    val searchResultState = _searchResultState.asStateFlow()
 
     private val _selectedItem = MutableStateFlow<MedicineItem?>(null)
     val selectedItem = _selectedItem.asStateFlow()
@@ -22,17 +26,35 @@ class MedicineViewModel(
     private val _recentSearches = MutableStateFlow<List<String>>(emptyList())
     val recentSearches = _recentSearches.asStateFlow()
 
-    fun searchMedicine(query: String) {
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery = _searchQuery.asStateFlow()
+
+    fun onQueryChange(query: String, medicineApiKey: String) {
+        _searchQuery.value = query
+
+        if (query.isNotBlank()) {
+            searchMedicine(medicineApiKey, query)
+        } else {
+            _searchResultState.value = UiState.Success(emptyList())
+        }
+    }
+
+    private fun searchMedicine(medicineApiKey: String, query: String) {
         viewModelScope.launch {
-            Log.d("API_TEST", "ViewModel: Repository에 검색 요청")
-            val result = repository.searchMedicines(query)
+            _searchResultState.value = UiState.Loading
+            Log.d("API_TEST", "ViewModel: Repository에 검색 요청 (쿼리: $query)")
+
+            val result = medicineSearchUseCase(
+                medicineApiKey = medicineApiKey,
+                query = query
+            )
 
             result.onSuccess { items ->
                 Log.d("API_TEST", "ViewModel: Repository로부터 성공 응답 받음, ${items.size}개")
-                _medicineList.value = items
+                _searchResultState.value = UiState.Success(items)
             }.onFailure { throwable ->
                 Log.e("API_TEST", "ViewModel: Repository로부터 실패 응답 받음", throwable)
-                _medicineList.value = emptyList()
+                _searchResultState.value = UiState.Error(throwable.message ?: "알 수 없는 에러")
             }
         }
     }
@@ -46,17 +68,19 @@ class MedicineViewModel(
         val trimmedQuery = query.trim()
         if (trimmedQuery.isBlank()) return
 
-        val currentList = _recentSearches.value.toMutableList()
-        currentList.remove(trimmedQuery)
-        currentList.add(0, trimmedQuery)
-
-        _recentSearches.value = currentList.take(10)
+        _recentSearches.update { currentList ->
+            val newList = currentList.toMutableList().apply {
+                remove(trimmedQuery)
+                add(0, trimmedQuery)
+            }
+            newList.take(10)
+        }
     }
 
     fun removeRecentSearch(query: String) {
-        val currentList = _recentSearches.value.toMutableList()
-        currentList.remove(query)
-        _recentSearches.value = currentList
+        _recentSearches.update { currentList ->
+            currentList.filter { it != query }
+        }
     }
 
     fun clearRecentSearches() {

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/DietSearchScreen.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/DietSearchScreen.kt
@@ -56,7 +56,7 @@ fun DietSearchScreen(
 	var errorMessage by remember { mutableStateOf<String?>(null) }
 	var isLoading by remember { mutableStateOf(false) }
 	
-	val API_KEY =
+	val API_KEY = ""
 	
 	
 	Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {


### PR DESCRIPTION
## 📝 작업 내용 
- 약 검색 결과에 필요한 공공데이터 api를 secret.properties에 저장되도록 하였습니다.
- UiState와 collectAsStateWithLifeCycle를 사용하도록 코드를 수정하였습니다.

## 📑 상세 설명 
- 공공데이터 api를 secret.properties에 등록
- UiState 사용
- collectAsState대신 collectAsStateWithLifeCycle 적용

#14