### PR TITLE
feat: 운동 세부기능 구현

### DIFF
--- a/data/src/main/java/com/cases/carefull/data/model/ExerciseCollectionDTO.kt
+++ b/data/src/main/java/com/cases/carefull/data/model/ExerciseCollectionDTO.kt
@@ -1,6 +1,7 @@
 package com.cases.carefull.data.model
 
 import com.cases.carefull.domain.model.exercise.ExerciseCollection
+import com.cases.carefull.domain.model.exercise.ExerciseType
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.ServerTimestamp
 
@@ -19,7 +20,7 @@ data class ExerciseCollectionDTO(
 fun ExerciseCollection.toFirestoreExerciseCollectionDTO(): ExerciseCollectionDTO {
 	return ExerciseCollectionDTO(
 		user_id = this.userId,
-		category_id = this.exerciseType,
+		category_id = this.exerciseType.name,
 		count = this.count,
 		created_at = null,
 		updated_at = null,
@@ -31,7 +32,7 @@ fun ExerciseCollection.toFirestoreExerciseCollectionDTO(): ExerciseCollectionDTO
 fun ExerciseCollectionDTO.toDomainExerciseCollection(): ExerciseCollection {
 	return ExerciseCollection(
 		userId = this.user_id,
-		exerciseType = this.category_id,
+		exerciseType = ExerciseType.entries.find { it.name == this.category_id } ?: ExerciseType.SQUAT,
 		count = this.count,
 		createdAt = this.created_at?.toDate()?.time ?: 0L,
 		updatedAt = this.updated_at?.toDate()?.time ?: 0L,

--- a/data/src/main/java/com/cases/carefull/data/model/ExerciseCollectionDTO.kt
+++ b/data/src/main/java/com/cases/carefull/data/model/ExerciseCollectionDTO.kt
@@ -11,7 +11,9 @@ data class ExerciseCollectionDTO(
 	@ServerTimestamp
 	val created_at: Timestamp? = null,
 	@ServerTimestamp
-	val updated_at: Timestamp? = null
+	val updated_at: Timestamp? = null,
+	val weekly_counts: Map<String, Int> = emptyMap(),
+	val daily_counts:Map<String,Int> = emptyMap()
 )
 
 fun ExerciseCollection.toFirestoreExerciseCollectionDTO(): ExerciseCollectionDTO {
@@ -20,7 +22,9 @@ fun ExerciseCollection.toFirestoreExerciseCollectionDTO(): ExerciseCollectionDTO
 		category_id = this.exerciseType,
 		count = this.count,
 		created_at = null,
-		updated_at = null
+		updated_at = null,
+		weekly_counts = this.weeklyCounts,
+		daily_counts = this.dailyCounts
 	)
 }
 
@@ -30,7 +34,9 @@ fun ExerciseCollectionDTO.toDomainExerciseCollection(): ExerciseCollection {
 		exerciseType = this.category_id,
 		count = this.count,
 		createdAt = this.created_at?.toDate()?.time ?: 0L,
-		updatedAt = this.updated_at?.toDate()?.time ?: 0L
+		updatedAt = this.updated_at?.toDate()?.time ?: 0L,
+		weeklyCounts = this.weekly_counts,
+		dailyCounts = this.daily_counts
 	)
 }
 

--- a/data/src/main/java/com/cases/carefull/data/repository/ExerciseRepositoryImpl.kt
+++ b/data/src/main/java/com/cases/carefull/data/repository/ExerciseRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.cases.carefull.data.repository
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
@@ -13,11 +14,19 @@ import com.cases.carefull.domain.model.exercise.ExerciseType
 import com.cases.carefull.domain.repository.ExerciseRepository
 import com.cases.carefull.domain.util.DataResourceResult
 import com.google.firebase.Firebase
+import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.firestore
+import com.google.firebase.firestore.toObjects
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.time.temporal.WeekFields
+import java.util.Calendar
+import java.util.Locale
 
 class ExerciseRepositoryImpl(
     private val context: Context
@@ -27,11 +36,66 @@ class ExerciseRepositoryImpl(
         const val PREFS_NAME = "daily_exercise_prefs"
         const val KEY_LAST_FETCH_DATE = "last_fetch_date"
         const val KEY_DAILY_EXERCISE = "daily_exercise_name"
+        
+        // [추가] 오늘의 운동 완료 기록을 위한 SharedPreferences
+        const val COMPLETION_PREFS_NAME = "exercise_completion_prefs"
+        const val KEY_COMPLETED_DATES_PREFIX = "completed_dates_"
     }
     private val prefs: SharedPreferences by lazy {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     }
-
+    
+    private val completionPrefs: SharedPreferences by lazy {
+        context.getSharedPreferences(COMPLETION_PREFS_NAME, Context.MODE_PRIVATE)
+    }
+    
+    @RequiresApi(Build.VERSION_CODES.O)
+	override fun getCompletedDailyExerciseDatesFlow(userId: String): Flow<Set<LocalDate>> = callbackFlow {
+        val key = "$KEY_COMPLETED_DATES_PREFIX$userId"
+        
+        // 1. 리스너 정의
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, changedKey ->
+            // 변경된 키가 우리가 감시하는 키와 일치할 때만 동작
+            if (changedKey == key) {
+                val dateStrings = sharedPreferences.getStringSet(key, emptySet()) ?: emptySet()
+                // 변경된 최신 데이터를 Flow로 전달
+                trySend(dateStrings.map { LocalDate.parse(it) }.toSet())
+            }
+        }
+        
+        // 2. 현재 값을 한 번 방출
+        val initialDateStrings = completionPrefs.getStringSet(key, emptySet()) ?: emptySet()
+        trySend(initialDateStrings.map { LocalDate.parse(it) }.toSet())
+        
+        // 3. 리스너 등록
+        completionPrefs.registerOnSharedPreferenceChangeListener(listener)
+        
+        // 4. Flow가 취소되면 리스너 제거
+        awaitClose { completionPrefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+    
+    override fun getExerciseStatFlow(userId: String): Flow<List<ExerciseCollection>> = callbackFlow {
+        // 1. 실시간 변경을 감지할 리스너 등록
+        val listenerRegistration = db.collection("work_out_collection")
+            .whereEqualTo("user_id", userId)
+            .addSnapshotListener { snapshot, error ->
+                // 에러 발생 시 Flow를 에러 상태로 종료
+                if (error != null) {
+                    close(error)
+                    return@addSnapshotListener
+                }
+                
+                // 스냅샷이 null이 아니면 데이터를 파싱하여 Flow로 전달
+                if (snapshot != null) {
+                    val dtoList = snapshot.toObjects<ExerciseCollectionDTO>()
+                    trySend(dtoList.toDomainExerciseCollectionList())
+                }
+            }
+        
+        // 2. Flow의 수집이 중단되면 (Coroutine이 취소되면) 리스너를 자동으로 제거
+        awaitClose { listenerRegistration.remove() }
+    }
+    
     override suspend fun getExerciseStat(userId: String) =
         runCatching {
             val snapshot = db.collection("work_out_collection")
@@ -60,36 +124,142 @@ class ExerciseRepositoryImpl(
         }
         return listOf(newDailyExercise)
     }
-
-    override suspend fun addExerciseRecord(
+    
+    @SuppressLint("DefaultLocale")
+	@RequiresApi(Build.VERSION_CODES.O)
+	override suspend fun addExerciseRecord(
         exerciseRecord: ExerciseCollection
-    ) = runCatching {
-        val querySnapshot = db.collection("work_out_collection")
+    ): Boolean = runCatching {
+        // 1. "년도-W주차" 형식의 키 생성 (예: "2025-W36")
+        val today = LocalDate.now()
+        val weekFields = WeekFields.ISO
+        
+        // [수정] 달력 연도 대신 '주차 기준 연도'를 가져옵니다.
+        val weekBasedYear = today.get(weekFields.weekBasedYear())
+        val weekOfYear = today.get(weekFields.weekOfWeekBasedYear())
+        
+        // 이제 키는 항상 같은 주에 대해 동일한 연도를 가집니다.
+        // 예: 2024-12-30 -> "2025-W01", 2025-01-01 -> "2025-W01"
+        val weekKey = "${weekBasedYear}-W${String.format("%02d", weekOfYear)}"
+        val dailyKey = today.format(DateTimeFormatter.ISO_LOCAL_DATE)
+        
+        val countToAdd = exerciseRecord.count.toLong()
+        
+        val collectionRef = db.collection("work_out_collection")
+        val query = collectionRef
             .whereEqualTo("user_id", exerciseRecord.userId)
             .whereEqualTo("category_id", exerciseRecord.exerciseType)
             .limit(1)
-            .get()
-            .await()
-
-        if (querySnapshot.isEmpty) {
-            val dto = exerciseRecord.toFirestoreExerciseCollectionDTO()
-            db.collection("work_out_collection").add(dto).await()
+        
+        val snapshot = query.get().await()
+        
+        if (snapshot.isEmpty) {
+            // 2. 문서가 없으면 새로 생성
+            val newDoc = ExerciseCollectionDTO(
+                user_id = exerciseRecord.userId,
+                category_id = exerciseRecord.exerciseType,
+                count = exerciseRecord.count,
+                weekly_counts = mapOf(weekKey to exerciseRecord.count),
+                daily_counts = mapOf(dailyKey to exerciseRecord.count)
+            )
+            collectionRef.add(newDoc).await()
         } else {
-            val documentRef = querySnapshot.documents.first().reference
-            val countToAdd = exerciseRecord.count.toLong()
-            documentRef.update(
+            // 3. 문서가 있으면 트랜잭션으로 안전하게 업데이트
+            val docRef = snapshot.documents.first().reference
+            docRef.update(
                 mapOf(
+                    // 총 횟수 누적
                     "count" to FieldValue.increment(countToAdd),
+                    // weekly_counts Map의 특정 주차 횟수 누적 (dot notation 사용)
+                    "weekly_counts.$weekKey" to FieldValue.increment(countToAdd),
+                    "daily_counts.$dailyKey" to FieldValue.increment(countToAdd),
+                    // 최종 업데이트 시간 갱신
                     "updated_at" to FieldValue.serverTimestamp()
                 )
             ).await()
         }
         true
     }.getOrElse {
+        it.printStackTrace() // 디버깅을 위해 에러 출력
         false
     }
+    
+    
+//    override suspend fun addExerciseRecord(
+//        exerciseRecord: ExerciseCollection
+//    ) = runCatching {
+//
+//        val querySnapshot = db.collection("work_out_collection")
+//            .whereEqualTo("user_id", exerciseRecord.userId)
+//            .whereEqualTo("category_id", exerciseRecord.exerciseType)
+//            .limit(1)
+//            .get()
+//            .await()
+//
+//        if (querySnapshot.isEmpty) {
+//            val dto = exerciseRecord.toFirestoreExerciseCollectionDTO()
+//            db.collection("work_out_collection").add(dto).await()
+//        } else {
+//            val documentRef = querySnapshot.documents.first().reference
+//            val countToAdd = exerciseRecord.count.toLong()
+//            documentRef.update(
+//                mapOf(
+//                    "count" to FieldValue.increment(countToAdd),
+//                    "updated_at" to FieldValue.serverTimestamp()
+//                )
+//            ).await()
+//        }
+//        true
+//    }.getOrElse {
+//        false
+//    }
 
     override suspend fun resetExercise(exercise: ExerciseCollection): DataResourceResult<Unit> {
         TODO("Not yet implemented")
+    }
+    
+    override suspend fun getTodaysExerciseCount(userId: String, exerciseType: ExerciseType): Int {
+        return runCatching {
+            // 오늘의 시작과 끝 타임스탬프 계산
+            val today = Calendar.getInstance()
+            today.set(Calendar.HOUR_OF_DAY, 0)
+            today.set(Calendar.MINUTE, 0)
+            today.set(Calendar.SECOND, 0)
+            today.set(Calendar.MILLISECOND, 0)
+            val startOfToday = Timestamp(today.time)
+            
+            today.add(Calendar.DAY_OF_MONTH, 1)
+            val startOfTomorrow = Timestamp(today.time)
+            
+            val snapshot = db.collection("work_out_collection")
+                .whereEqualTo("user_id", userId)
+                .whereEqualTo("category_id", exerciseType.name)
+                .whereGreaterThanOrEqualTo("updated_at", startOfToday)
+                .whereLessThan("updated_at", startOfTomorrow)
+                .get()
+                .await()
+            
+            val dtoList = snapshot.toObjects(ExerciseCollectionDTO::class.java)
+            dtoList.sumOf { it.count }
+        }.getOrElse {
+            0
+        }
+    }
+    
+    @RequiresApi(Build.VERSION_CODES.O)
+	override suspend fun getCompletedDailyExerciseDates(userId: String): Set<LocalDate> {
+        val key = "$KEY_COMPLETED_DATES_PREFIX$userId"
+        val dateStrings = completionPrefs.getStringSet(key, emptySet()) ?: emptySet()
+        return dateStrings.map { LocalDate.parse(it) }.toSet()
+    }
+    
+    @RequiresApi(Build.VERSION_CODES.O)
+	override suspend fun markDailyExerciseAsCompleted(userId: String, date: LocalDate) {
+        val key = "$KEY_COMPLETED_DATES_PREFIX$userId"
+        val currentDates = getCompletedDailyExerciseDates(userId).map { it.toString() }.toMutableSet()
+        currentDates.add(date.toString())
+        completionPrefs.edit {
+            putStringSet(key, currentDates)
+        }
     }
 }

--- a/data/src/main/java/com/cases/carefull/data/repository/ExerciseRepositoryImpl.kt
+++ b/data/src/main/java/com/cases/carefull/data/repository/ExerciseRepositoryImpl.kt
@@ -8,7 +8,6 @@ import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import com.cases.carefull.data.model.ExerciseCollectionDTO
 import com.cases.carefull.data.model.toDomainExerciseCollectionList
-import com.cases.carefull.data.model.toFirestoreExerciseCollectionDTO
 import com.cases.carefull.domain.model.exercise.ExerciseCollection
 import com.cases.carefull.domain.model.exercise.ExerciseType
 import com.cases.carefull.domain.repository.ExerciseRepository
@@ -26,7 +25,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.WeekFields
 import java.util.Calendar
-import java.util.Locale
 
 class ExerciseRepositoryImpl(
     private val context: Context
@@ -36,8 +34,6 @@ class ExerciseRepositoryImpl(
         const val PREFS_NAME = "daily_exercise_prefs"
         const val KEY_LAST_FETCH_DATE = "last_fetch_date"
         const val KEY_DAILY_EXERCISE = "daily_exercise_name"
-        
-        // [추가] 오늘의 운동 완료 기록을 위한 SharedPreferences
         const val COMPLETION_PREFS_NAME = "exercise_completion_prefs"
         const val KEY_COMPLETED_DATES_PREFIX = "completed_dates_"
     }
@@ -52,47 +48,31 @@ class ExerciseRepositoryImpl(
     @RequiresApi(Build.VERSION_CODES.O)
 	override fun getCompletedDailyExerciseDatesFlow(userId: String): Flow<Set<LocalDate>> = callbackFlow {
         val key = "$KEY_COMPLETED_DATES_PREFIX$userId"
-        
-        // 1. 리스너 정의
         val listener = SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, changedKey ->
-            // 변경된 키가 우리가 감시하는 키와 일치할 때만 동작
             if (changedKey == key) {
                 val dateStrings = sharedPreferences.getStringSet(key, emptySet()) ?: emptySet()
-                // 변경된 최신 데이터를 Flow로 전달
                 trySend(dateStrings.map { LocalDate.parse(it) }.toSet())
             }
         }
-        
-        // 2. 현재 값을 한 번 방출
         val initialDateStrings = completionPrefs.getStringSet(key, emptySet()) ?: emptySet()
         trySend(initialDateStrings.map { LocalDate.parse(it) }.toSet())
-        
-        // 3. 리스너 등록
         completionPrefs.registerOnSharedPreferenceChangeListener(listener)
-        
-        // 4. Flow가 취소되면 리스너 제거
         awaitClose { completionPrefs.unregisterOnSharedPreferenceChangeListener(listener) }
     }
     
     override fun getExerciseStatFlow(userId: String): Flow<List<ExerciseCollection>> = callbackFlow {
-        // 1. 실시간 변경을 감지할 리스너 등록
         val listenerRegistration = db.collection("work_out_collection")
             .whereEqualTo("user_id", userId)
             .addSnapshotListener { snapshot, error ->
-                // 에러 발생 시 Flow를 에러 상태로 종료
                 if (error != null) {
                     close(error)
                     return@addSnapshotListener
                 }
-                
-                // 스냅샷이 null이 아니면 데이터를 파싱하여 Flow로 전달
                 if (snapshot != null) {
                     val dtoList = snapshot.toObjects<ExerciseCollectionDTO>()
                     trySend(dtoList.toDomainExerciseCollectionList())
                 }
             }
-        
-        // 2. Flow의 수집이 중단되면 (Coroutine이 취소되면) 리스너를 자동으로 제거
         awaitClose { listenerRegistration.remove() }
     }
     
@@ -130,16 +110,10 @@ class ExerciseRepositoryImpl(
 	override suspend fun addExerciseRecord(
         exerciseRecord: ExerciseCollection
     ): Boolean = runCatching {
-        // 1. "년도-W주차" 형식의 키 생성 (예: "2025-W36")
         val today = LocalDate.now()
         val weekFields = WeekFields.ISO
-        
-        // [수정] 달력 연도 대신 '주차 기준 연도'를 가져옵니다.
         val weekBasedYear = today.get(weekFields.weekBasedYear())
         val weekOfYear = today.get(weekFields.weekOfWeekBasedYear())
-        
-        // 이제 키는 항상 같은 주에 대해 동일한 연도를 가집니다.
-        // 예: 2024-12-30 -> "2025-W01", 2025-01-01 -> "2025-W01"
         val weekKey = "${weekBasedYear}-W${String.format("%02d", weekOfYear)}"
         val dailyKey = today.format(DateTimeFormatter.ISO_LOCAL_DATE)
         
@@ -148,79 +122,39 @@ class ExerciseRepositoryImpl(
         val collectionRef = db.collection("work_out_collection")
         val query = collectionRef
             .whereEqualTo("user_id", exerciseRecord.userId)
-            .whereEqualTo("category_id", exerciseRecord.exerciseType)
+            .whereEqualTo("category_id", exerciseRecord.exerciseType.name)
             .limit(1)
         
         val snapshot = query.get().await()
         
         if (snapshot.isEmpty) {
-            // 2. 문서가 없으면 새로 생성
             val newDoc = ExerciseCollectionDTO(
                 user_id = exerciseRecord.userId,
-                category_id = exerciseRecord.exerciseType,
+                category_id = exerciseRecord.exerciseType.name,
                 count = exerciseRecord.count,
                 weekly_counts = mapOf(weekKey to exerciseRecord.count),
                 daily_counts = mapOf(dailyKey to exerciseRecord.count)
             )
             collectionRef.add(newDoc).await()
         } else {
-            // 3. 문서가 있으면 트랜잭션으로 안전하게 업데이트
             val docRef = snapshot.documents.first().reference
             docRef.update(
                 mapOf(
-                    // 총 횟수 누적
                     "count" to FieldValue.increment(countToAdd),
-                    // weekly_counts Map의 특정 주차 횟수 누적 (dot notation 사용)
                     "weekly_counts.$weekKey" to FieldValue.increment(countToAdd),
                     "daily_counts.$dailyKey" to FieldValue.increment(countToAdd),
-                    // 최종 업데이트 시간 갱신
                     "updated_at" to FieldValue.serverTimestamp()
                 )
             ).await()
         }
         true
     }.getOrElse {
-        it.printStackTrace() // 디버깅을 위해 에러 출력
+        it.printStackTrace()
         false
-    }
-    
-    
-//    override suspend fun addExerciseRecord(
-//        exerciseRecord: ExerciseCollection
-//    ) = runCatching {
-//
-//        val querySnapshot = db.collection("work_out_collection")
-//            .whereEqualTo("user_id", exerciseRecord.userId)
-//            .whereEqualTo("category_id", exerciseRecord.exerciseType)
-//            .limit(1)
-//            .get()
-//            .await()
-//
-//        if (querySnapshot.isEmpty) {
-//            val dto = exerciseRecord.toFirestoreExerciseCollectionDTO()
-//            db.collection("work_out_collection").add(dto).await()
-//        } else {
-//            val documentRef = querySnapshot.documents.first().reference
-//            val countToAdd = exerciseRecord.count.toLong()
-//            documentRef.update(
-//                mapOf(
-//                    "count" to FieldValue.increment(countToAdd),
-//                    "updated_at" to FieldValue.serverTimestamp()
-//                )
-//            ).await()
-//        }
-//        true
-//    }.getOrElse {
-//        false
-//    }
-
-    override suspend fun resetExercise(exercise: ExerciseCollection): DataResourceResult<Unit> {
-        TODO("Not yet implemented")
     }
     
     override suspend fun getTodaysExerciseCount(userId: String, exerciseType: ExerciseType): Int {
         return runCatching {
-            // 오늘의 시작과 끝 타임스탬프 계산
             val today = Calendar.getInstance()
             today.set(Calendar.HOUR_OF_DAY, 0)
             today.set(Calendar.MINUTE, 0)

--- a/domain/src/main/java/com/cases/carefull/domain/model/exercise/ExerciseCollection.kt
+++ b/domain/src/main/java/com/cases/carefull/domain/model/exercise/ExerciseCollection.kt
@@ -5,5 +5,7 @@ data class ExerciseCollection(
 	val exerciseType: String = "",
 	val count: Int = 0,
 	val createdAt: Long = 0,
-	val updatedAt: Long = 0
+	val updatedAt: Long = 0,
+	val weeklyCounts: Map<String, Int> = emptyMap(),
+	val dailyCounts: Map<String, Int> = emptyMap()
 )

--- a/domain/src/main/java/com/cases/carefull/domain/model/exercise/ExerciseCollection.kt
+++ b/domain/src/main/java/com/cases/carefull/domain/model/exercise/ExerciseCollection.kt
@@ -2,7 +2,7 @@ package com.cases.carefull.domain.model.exercise
 
 data class ExerciseCollection(
 	val userId: String = "test",
-	val exerciseType: String = "",
+	val exerciseType: ExerciseType,
 	val count: Int = 0,
 	val createdAt: Long = 0,
 	val updatedAt: Long = 0,

--- a/domain/src/main/java/com/cases/carefull/domain/model/exercise/ExerciseRecordForDate.kt
+++ b/domain/src/main/java/com/cases/carefull/domain/model/exercise/ExerciseRecordForDate.kt
@@ -1,0 +1,6 @@
+package com.cases.carefull.domain.model.exercise
+
+data class ExerciseRecordForDate(
+	val name: String,
+	val count: Int
+)

--- a/domain/src/main/java/com/cases/carefull/domain/repository/ExerciseRepository.kt
+++ b/domain/src/main/java/com/cases/carefull/domain/repository/ExerciseRepository.kt
@@ -14,7 +14,6 @@ interface ExerciseRepository {
 	suspend fun getExerciseStat(userId:String): List<ExerciseCollection>
 	suspend fun getDailyExerciseList(): List<ExerciseType>
 	suspend fun addExerciseRecord(exerciseRecord: ExerciseCollection): Boolean
-	suspend fun resetExercise(exercise: ExerciseCollection): DataResourceResult<Unit>
 	suspend fun getTodaysExerciseCount(userId: String, exerciseType: ExerciseType): Int
 	suspend fun getCompletedDailyExerciseDates(userId: String): Set<LocalDate>
 	suspend fun markDailyExerciseAsCompleted(userId: String, date: LocalDate)

--- a/domain/src/main/java/com/cases/carefull/domain/repository/ExerciseRepository.kt
+++ b/domain/src/main/java/com/cases/carefull/domain/repository/ExerciseRepository.kt
@@ -3,10 +3,19 @@ package com.cases.carefull.domain.repository
 import com.cases.carefull.domain.model.exercise.ExerciseCollection
 import com.cases.carefull.domain.model.exercise.ExerciseType
 import com.cases.carefull.domain.util.DataResourceResult
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
 
 interface ExerciseRepository {
+	
+	fun getExerciseStatFlow(userId:String): Flow<List<ExerciseCollection>>
+	
+	fun getCompletedDailyExerciseDatesFlow(userId: String): Flow<Set<LocalDate>>
 	suspend fun getExerciseStat(userId:String): List<ExerciseCollection>
 	suspend fun getDailyExerciseList(): List<ExerciseType>
 	suspend fun addExerciseRecord(exerciseRecord: ExerciseCollection): Boolean
 	suspend fun resetExercise(exercise: ExerciseCollection): DataResourceResult<Unit>
+	suspend fun getTodaysExerciseCount(userId: String, exerciseType: ExerciseType): Int
+	suspend fun getCompletedDailyExerciseDates(userId: String): Set<LocalDate>
+	suspend fun markDailyExerciseAsCompleted(userId: String, date: LocalDate)
 }

--- a/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/Calendar.kt
+++ b/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/Calendar.kt
@@ -308,6 +308,7 @@ private fun RowScope.CalendarDayBox(
 		val isToday = date == LocalDate.now()
 		
 		val hasLoggedMeal = calendarState.markedDates.contains(date)
+		val hasCompletedDailyExercise = calendarState.dailyExerciseCompletedDates.contains(date)
 		
 		CalendarDay(
 			date = date,
@@ -315,6 +316,7 @@ private fun RowScope.CalendarDayBox(
 			isSelected = isSelected,
 			isVisibleMonth = if (calendarState.viewType == CalendarViewType.WEEKLY) true else isVisibleMonth,
 			hasLoggedMeal = hasLoggedMeal,
+			hasCompletedDailyExercise = hasCompletedDailyExercise,
 			onClick = onClick
 		)
 	}

--- a/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/Calendar.kt
+++ b/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/Calendar.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
@@ -63,7 +64,8 @@ fun Calendar(
 	onDateClick: (LocalDate) -> Unit,
 	onToggleViewType: () -> Unit,
 	onMonthPickerClick: () -> Unit,
-	onGoToToday: () -> Unit
+	onGoToToday: () -> Unit,
+	calendarFooterContent: (@Composable ColumnScope.() -> Unit)? = null
 ) {
 	var totalDragY by remember { mutableFloatStateOf(0f) }
 	val swipeThreshold = with(LocalDensity.current) { 50.dp.toPx() }
@@ -106,7 +108,8 @@ fun Calendar(
 				onDateClick = onDateClick
 			)
 			CalendarFooter(
-				selectedDateInfo = calendarState.selectedDateInfo
+				selectedDateInfo = calendarState.selectedDateInfo,
+				content = calendarFooterContent
 			)
 		}
 	}
@@ -145,7 +148,6 @@ private fun CalendarHeader(
 			.height(56.dp)
 			.padding(horizontal = 16.dp)
 	) {
-		
 		Row(
 			verticalAlignment = Alignment.CenterVertically,
 			modifier = Modifier
@@ -164,7 +166,6 @@ private fun CalendarHeader(
 				fontWeight = FontWeight.SemiBold
 			)
 		}
-		
 		Row(
 			modifier = Modifier
 				.align(Alignment.CenterEnd)
@@ -275,22 +276,34 @@ private fun CalendarGrid(
 }
 
 @Composable
-private fun CalendarFooter(selectedDateInfo: String) {
-	Spacer(modifier = Modifier.height(8.dp))
-	Row(
-		modifier = Modifier.fillMaxWidth(),
-		horizontalArrangement = Arrangement.End
-	) {
-		Text(
-			text = selectedDateInfo,
-			style = MaterialTheme.typography.titleSmall,
-			color = Color.Gray,
-			modifier = Modifier.padding(end = 16.dp)
-		)
+private fun CalendarFooter(
+	selectedDateInfo: String,
+	content: (@Composable ColumnScope.() -> Unit)?
+) {
+	Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+		if (content != null) {
+			Column(
+				verticalArrangement = Arrangement.spacedBy(12.dp)
+			) {
+				content()
+			}
+		}
+		
+		Row(
+			modifier = Modifier
+				.fillMaxWidth()
+				.padding(top = 8.dp),
+			horizontalArrangement = Arrangement.End
+		) {
+			Text(
+				text = selectedDateInfo,
+				style = MaterialTheme.typography.bodySmall,
+				color = Color.Gray
+			)
+		}
+		Spacer(modifier = Modifier.height(12.dp))
 	}
-	Spacer(modifier = Modifier.height(8.dp))
 }
-
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 private fun RowScope.CalendarDayBox(

--- a/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/CalendarDay.kt
+++ b/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/CalendarDay.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,6 +36,7 @@ fun CalendarDay(
 	isSelected: Boolean,
 	isVisibleMonth: Boolean,
 	hasLoggedMeal: Boolean,
+	hasCompletedDailyExercise: Boolean,
 	onClick: () -> Unit
 ) {
 	val textColor = remember(isToday, isVisibleMonth) {
@@ -82,7 +84,14 @@ fun CalendarDay(
 					color = textColor
 				)
 			}
-			if (hasLoggedMeal) {
+			if (hasCompletedDailyExercise) {
+				Icon(
+					imageVector = Icons.Default.CheckCircle,
+					contentDescription = "오늘의 운동 완료",
+					modifier = Modifier.size(12.dp),
+					tint = MaterialTheme.colorScheme.primary
+				)
+			} else if (hasLoggedMeal) {
 				Icon(
 					imageVector = Icons.Default.CheckCircle,
 					contentDescription = "식단 기록 완료",

--- a/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/CalendarDay.kt
+++ b/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/CalendarDay.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -54,7 +55,6 @@ fun CalendarDay(
 			Color.White
 		}
 	}
-	
 	Surface(
 		modifier = Modifier.clickable(
 			interactionSource = remember { MutableInteractionSource() },
@@ -84,20 +84,23 @@ fun CalendarDay(
 					color = textColor
 				)
 			}
-			if (hasCompletedDailyExercise) {
-				Icon(
-					imageVector = Icons.Default.CheckCircle,
-					contentDescription = "오늘의 운동 완료",
-					modifier = Modifier.size(12.dp),
-					tint = MaterialTheme.colorScheme.primary
-				)
-			} else if (hasLoggedMeal) {
-				Icon(
-					imageVector = Icons.Default.CheckCircle,
-					contentDescription = "식단 기록 완료",
-					modifier = Modifier.size(12.dp),
-					tint = Color(0xFF4CAF50)
-				)
+			Row {
+				if (hasCompletedDailyExercise) {
+					Icon(
+						imageVector = Icons.Default.CheckCircle,
+						contentDescription = "오늘의 운동 완료",
+						modifier = Modifier.size(12.dp),
+						tint = MaterialTheme.colorScheme.onErrorContainer
+					)
+				}
+				if (hasLoggedMeal) {
+					Icon(
+						imageVector = Icons.Default.CheckCircle,
+						contentDescription = "식단 기록 완료",
+						modifier = Modifier.size(12.dp),
+						tint = Color(0xFF4CAF50)
+					)
+				}
 			}
 		}
 	}

--- a/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/CalendarState.kt
+++ b/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/CalendarState.kt
@@ -13,5 +13,6 @@ data class CalendarState(
 	val viewType: CalendarViewType = CalendarViewType.WEEKLY,
 	val calendarDates: List<LocalDate>,
 	val selectedDateInfo: String,
-	val markedDates: Set<LocalDate> = emptySet()
+	val markedDates: Set<LocalDate> = emptySet(),
+	val dailyExerciseCompletedDates: Set<LocalDate> = emptySet()
 )

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/ExerciseScreen.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/ExerciseScreen.kt
@@ -1,6 +1,10 @@
 package com.cases.carefull.features.carefullcontents.routine.exercise
 
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -47,12 +51,15 @@ import androidx.navigation.NavController
 import com.cases.carefull.domain.model.exercise.ExerciseType
 import com.cases.carefull.features.carefullcommon.navigation.RoutineRoute
 
+@RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun ExerciseScreen(
 	viewModel: ExerciseViewModel,
 	navController: NavController
 ) {
 	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+	val todayExercise = uiState.dailyExercise.firstOrNull()
+	
 	
 	if (uiState.showDialog && uiState.selectedExercise != null) {
 		ExerciseCountDialog(
@@ -117,8 +124,10 @@ fun ExerciseScreen(
 				items = uiState.exerciseList,
 				key = { it.type.name }
 			) { exerciseUiModel ->
+				val isTodayExercise = exerciseUiModel.type == todayExercise
 				ExerciseCard(
 					uiModel = exerciseUiModel,
+					isTodayExercise = isTodayExercise,
 					onClick = {
 						viewModel.onExerciseSelected(exerciseUiModel.type)
 					}
@@ -132,12 +141,27 @@ fun ExerciseScreen(
 @Composable
 fun ExerciseCard(
 	uiModel: ExerciseUiModel,
+	isTodayExercise: Boolean,
 	onClick: () -> Unit,
 	modifier: Modifier = Modifier
 ) {
+	val cardModifier = if (isTodayExercise) {
+		modifier
+			.fillMaxWidth()
+			.then(
+				Modifier.border(
+					BorderStroke(2.dp, MaterialTheme.colorScheme.primary),
+					RoundedCornerShape(16.dp)
+				)
+			)
+	} else {
+		modifier.fillMaxWidth()
+	}
+	
 	Card(
 		onClick = onClick,
-		modifier = modifier.fillMaxWidth(),
+		modifier = cardModifier,
+		shape = RoundedCornerShape(16.dp),
 		elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
 	) {
 		Row(
@@ -168,12 +192,26 @@ fun ExerciseCard(
 					color = MaterialTheme.colorScheme.onSurfaceVariant,
 				)
 				Spacer(modifier = Modifier.height(8.dp))
-				Text(
-					text = "총 ${uiModel.totalCount}회 수행",
-					style = MaterialTheme.typography.bodySmall,
-					color = MaterialTheme.colorScheme.primary,
-					fontWeight = FontWeight.SemiBold
-				)
+				Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+					Text(
+						text = "오늘 ${uiModel.dailyCount}회",
+						style = MaterialTheme.typography.bodySmall,
+						color = MaterialTheme.colorScheme.secondary,
+						fontWeight = FontWeight.Bold
+					)
+					Text(
+						text = "이번 주 ${uiModel.weeklyCount}회",
+						style = MaterialTheme.typography.bodySmall,
+						color = Color.Gray,
+						fontWeight = FontWeight.SemiBold
+					)
+					Text(
+						text = "총 ${uiModel.totalCount}회",
+						style = MaterialTheme.typography.bodySmall,
+						color = MaterialTheme.colorScheme.primary,
+						fontWeight = FontWeight.SemiBold
+					)
+				}
 			}
 		}
 	}

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/ExerciseScreenUiModel.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/ExerciseScreenUiModel.kt
@@ -10,38 +10,49 @@ data class ExerciseUiModel(
     @param:DrawableRes
     val imageResId: Int,
     val description: String,
-    val totalCount: Int = 0
+    val totalCount: Int = 0,
+    //
+    val weeklyCount: Int = 0,
+    val dailyCount: Int = 0
 )
 
-fun ExerciseType.toUiModel(count: Int): ExerciseUiModel {
+fun ExerciseType.toUiModel(totalCount: Int, weeklyCount: Int, dailyCount: Int): ExerciseUiModel {
     return when (this) {
         ExerciseType.DUMBBELL_CURL -> ExerciseUiModel(
             type = this,
             name = "덤벨 컬",
             imageResId = R.drawable.dumbbell_curl,
             description = "이두근을 발달시키는 대표적인 운동으로,덤벨을 이용해 팔을 굽혔다 펴는 동작을 반복합니다.",
-            totalCount = count
+            totalCount = totalCount,
+            weeklyCount = weeklyCount,
+            dailyCount = dailyCount
         )
         ExerciseType.SQUAT -> ExerciseUiModel(
             type = this,
             name = "스쿼트",
             imageResId = R.drawable.squat,
             description = "쪼그려 앉는 동작을 반복하는 웨이트 트레이닝 운동입니다. 양발을 어깨 너비로 벌리고 서서 무릎을 굽혔다 펴는 동작을 통해 하체 근육을 강화합니다.",
-            totalCount = count
+            totalCount = totalCount,
+            weeklyCount = weeklyCount,
+            dailyCount = dailyCount
         )
         ExerciseType.PUSH_UP -> ExerciseUiModel(
             type = this,
             name = "푸쉬업",
             imageResId = R.drawable.push_up,
             description = "엎드린 자세에서 손과 발을 지지점으로 하여 몸을 바닥에서 밀어 올리는 전신 운동입니다.가슴, 어깨, 삼두근, 코어 근육 등을 발달에 효과적입니다.",
-            totalCount = count
+            totalCount = totalCount,
+            weeklyCount = weeklyCount,
+            dailyCount = dailyCount
         )
         ExerciseType.DUMBBELL_SHOULDER_PRESS -> ExerciseUiModel(
             type = this,
             name = "덤벨 숄더 프레스",
             imageResId = R.drawable.dumbbell_shoulder_press,
             description = "어깨 근육을 발달시키는 대표적인 운동으로, 덤벨을 이용하여 양쪽 어깨를 동시에 또는 번갈아 가며 머리 위로 밀어 올리는 동작으로, 어깨 근육을 키우는 데 효과적입니다. ",
-            totalCount = count
+            totalCount = totalCount,
+            weeklyCount = weeklyCount,
+            dailyCount = dailyCount
         )
     }
 }

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/ExerciseUiState.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/ExerciseUiState.kt
@@ -4,20 +4,28 @@ import com.cases.carefull.domain.model.exercise.ExerciseCollection
 import com.cases.carefull.domain.model.exercise.ExerciseState
 import com.cases.carefull.domain.model.exercise.ExerciseType
 import com.cases.carefull.domain.model.exercise.Pose
+import java.time.LocalDate
 
 data class ExerciseUiState(
 	val count: Int = 0,
 	val userPose: ExerciseState = ExerciseState.NONE,
 	val detectedPose: Pose? = null,
-
+	
 	val isLoading: Boolean = true,
 	val isError: Boolean = false,
-
+	
 	var showDialog: Boolean = false,
 	val selectedExercise: ExerciseType?=null,
 	val exercisesResults: List<ExerciseCollection> = emptyList(),
 	val exerciseCounts: Map<ExerciseType, Int> = emptyMap(),
 	val exerciseList: List<ExerciseUiModel> = emptyList(),
+	
+	val dailyExercise:List<ExerciseType> = emptyList(),
+	
+	val totalExerciseCounts: Map<ExerciseType, Int> = emptyMap(),
 
-	val dailyExercise:List<ExerciseType> = emptyList()
+	val weeklyExerciseCounts: Map<ExerciseType, Int> = emptyMap(),
+	val dailyExerciseCounts: Map<ExerciseType, Int> = emptyMap(),
+
+	val completedDailyExerciseDates: Set<LocalDate> = emptySet(),
 )

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/ExerciseViewModel.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/ExerciseViewModel.kt
@@ -1,5 +1,8 @@
 package com.cases.carefull.features.carefullcontents.routine.exercise
 
+import android.annotation.SuppressLint
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cases.carefull.domain.model.exercise.ExerciseCollection
@@ -16,127 +19,198 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.WeekFields
 
+@RequiresApi(Build.VERSION_CODES.O)
 class ExerciseViewModel(
-    private val exerciseRepository: ExerciseRepository
+	private val exerciseRepository: ExerciseRepository
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(ExerciseUiState())
-    val uiState = _uiState.asStateFlow()
-    private lateinit var analyzer: ExerciseAnalyzer
-
-    init {
-        loadInitialData()
-    }
-
-    fun loadInitialData() {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            try {
-                val exercises = exerciseRepository.getExerciseStat(userId = "test")
-                val groupedBySport = exercises.groupBy { it.exerciseType }
-                val countsMap = groupedBySport.mapNotNull { (sportName, records) ->
-                    ExerciseType.valueOf(sportName).let { type ->
-                        type to records.sumOf { it.count }
-                    }
-                }.toMap()
-                val dailyExercises = exerciseRepository.getDailyExerciseList()
-                val uiModelList = ExerciseType.entries.map { exerciseType ->
-                    val count = countsMap[exerciseType] ?: 0
-                    exerciseType.toUiModel(count)
-                }
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        exercisesResults = exercises,
-                        exerciseCounts = countsMap,
-                        exerciseList = uiModelList,
-                        dailyExercise = dailyExercises
-                    )
-                }
-            } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false, isError = true) }
-            }
-        }
-    }
-
-    fun initialize(exerciseType: ExerciseType) {
-        this.analyzer = createAnalyzer(exerciseType)
-        _uiState.update {
-            it.copy(
-                count = 0,
-                userPose = ExerciseState.NONE,
-                detectedPose = null
-            )
-        }
-    }
-
-    fun onPoseDetected(pose: Pose) {
-        if (!::analyzer.isInitialized) return
-        val newDetectedState = analyzer.analyze(pose)
-        _uiState.update {
-            val newCount =
-                if (it.userPose == ExerciseState.DOWN && newDetectedState == ExerciseState.UP) {
-                    it.count + 1
-                } else {
-                    it.count
-                }
-            val newUserPose =
-                if (newDetectedState == ExerciseState.UP || newDetectedState == ExerciseState.DOWN) {
-                    newDetectedState
-                } else {
-                    it.userPose
-                }
-            it.copy(
-                count = newCount,
-                userPose = newUserPose,
-                detectedPose = pose
-            )
-        }
-    }
-
-    fun saveWorkoutResult(exerciseType: ExerciseType) {
-        viewModelScope.launch {
-            val totalCount = _uiState.value.count
-
-            if (totalCount > 0) {
-                val recordToSave = ExerciseCollection(
-                    userId = "test",
-                    exerciseType = exerciseType.name,
-                    count = totalCount
-                )
-                val result = exerciseRepository.addExerciseRecord(recordToSave)
-                if (result) {
-                    loadInitialData()
-                } else {
-                    _uiState.update { it.copy(isError = true) }
-                }
-            }
-        }
-    }
-
-    fun onExerciseSelected(exerciseType: ExerciseType) {
-        _uiState.update {
-            it.copy(
-                selectedExercise = exerciseType,
-                showDialog = true
-            )
-        }
-    }
-
-    fun onDialogDismiss() {
-        _uiState.update { it.copy(showDialog = false) }
-    }
-
-    fun onDialogConfirm() {
-        _uiState.update { it.copy(showDialog = false) }
-    }
-
-    private fun createAnalyzer(type: ExerciseType): ExerciseAnalyzer {
-        return when (type) {
-            ExerciseType.DUMBBELL_CURL -> DumbbellCurlAnalyzer(isLeftHand = false)
-            ExerciseType.SQUAT -> SquatAnalyzer()
-            ExerciseType.PUSH_UP -> PushUpAnalyzer(isLeftHand = false)
-            ExerciseType.DUMBBELL_SHOULDER_PRESS -> DumbbellShoulderPressAnalyzer(isLeftHand = false)
-        }
-    }
+	private val _uiState = MutableStateFlow(ExerciseUiState())
+	val uiState = _uiState.asStateFlow()
+	private lateinit var analyzer: ExerciseAnalyzer
+	
+	companion object {
+		const val DAILY_EXERCISE_GOAL = 30
+	}
+	
+	init {
+		loadInitialData()
+	}
+	
+	@RequiresApi(Build.VERSION_CODES.O)
+	fun loadInitialData() {
+		viewModelScope.launch {
+			_uiState.update { it.copy(isLoading = true) }
+			try {
+				val exercises = exerciseRepository.getExerciseStat(userId = "test")
+				//
+				val dailyExercises = exerciseRepository.getDailyExerciseList()
+				val completedDates = exerciseRepository.getCompletedDailyExerciseDates("test")
+				
+				//
+				val totalCountsMap = exercises.associate {
+					ExerciseType.valueOf(it.exerciseType) to it.count
+				}
+				
+				//
+				val weeklyCountsMap = calculateWeeklyCounts(exercises)
+				val dailyCountsMap = calculateDailyCounts(exercises) // [추가]
+				
+				
+				val groupedBySport = exercises.groupBy { it.exerciseType }
+				val countsMap = groupedBySport.mapNotNull { (sportName, records) ->
+					ExerciseType.valueOf(sportName).let { type ->
+						type to records.sumOf { it.count }
+					}
+				}.toMap()
+				val uiModelList = ExerciseType.entries.map { exerciseType ->
+					val count = countsMap[exerciseType] ?: 0
+					val weeklyCount = weeklyCountsMap[exerciseType] ?: 0
+					val dailyCount = dailyCountsMap[exerciseType] ?: 0 // [추가]
+					//
+					exerciseType.toUiModel(count, weeklyCount, dailyCount)
+				}
+//                    exerciseType.toUiModel(count)      }
+				_uiState.update {
+					it.copy(
+						isLoading = false,
+						exercisesResults = exercises,
+						
+						totalExerciseCounts = totalCountsMap,
+						weeklyExerciseCounts = weeklyCountsMap,
+						dailyExerciseCounts = dailyCountsMap, // [추가]
+						completedDailyExerciseDates = completedDates,
+						
+						exerciseCounts = countsMap,
+						exerciseList = uiModelList,
+						dailyExercise = dailyExercises
+					)
+				}
+			} catch (e: Exception) {
+				_uiState.update { it.copy(isLoading = false, isError = true) }
+			}
+		}
+	}
+	private fun calculateDailyCounts(exercises: List<ExerciseCollection>): Map<ExerciseType, Int> {
+		val currentDailyKey = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+		return exercises.associate {
+			ExerciseType.valueOf(it.exerciseType) to (it.dailyCounts[currentDailyKey] ?: 0)
+		}
+	}
+	
+	// [수정] 이번 주 운동 횟수 계산 로직
+	@SuppressLint("DefaultLocale")
+	private fun calculateWeeklyCounts(exercises: List<ExerciseCollection>): Map<ExerciseType, Int> {
+		// "년도-W주차" 형식의 키 생성
+		val today = LocalDate.now()
+		val weekFields = WeekFields.ISO
+		
+		// [수정] 여기도 동일하게 '주차 기준 연도'를 사용해야 합니다.
+		val weekBasedYear = today.get(weekFields.weekBasedYear())
+		val weekOfYear = today.get(weekFields.weekOfWeekBasedYear())
+		
+		val currentWeekKey = "${weekBasedYear}-W${String.format("%02d", weekOfYear)}"
+		
+		// 각 운동의 weeklyCounts 맵에서 이번 주 키에 해당하는 값을 가져옴
+		return exercises.associate {
+			ExerciseType.valueOf(it.exerciseType) to (it.weeklyCounts[currentWeekKey] ?: 0)
+		}
+	}
+//	@RequiresApi(Build.VERSION_CODES.O)
+//	private fun calculateWeeklyCounts(exercises: List<ExerciseCollection>): Map<ExerciseType, Int> {
+//		val today = LocalDate.now()
+//		// 월요일을 주의 시작으로 설정
+//		val startOfWeek = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+//		val startOfWeekMillis =
+//			startOfWeek.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+//
+//		return exercises
+//			.filter { it.createdAt >= startOfWeekMillis } // 이번 주 기록만 필터링
+//			.groupBy { ExerciseType.valueOf(it.exerciseType) }
+//			.mapValues { (_, records) -> records.sumOf { it.count } }
+//	}
+	
+	fun initialize(exerciseType: ExerciseType) {
+		this.analyzer = createAnalyzer(exerciseType)
+		_uiState.update {
+			it.copy(
+				count = 0,
+				userPose = ExerciseState.NONE,
+				detectedPose = null
+			)
+		}
+	}
+	
+	fun onPoseDetected(pose: Pose) {
+		if (!::analyzer.isInitialized) return
+		val newDetectedState = analyzer.analyze(pose)
+		_uiState.update {
+			val newCount =
+				if (it.userPose == ExerciseState.DOWN && newDetectedState == ExerciseState.UP) {
+					it.count + 1
+				} else {
+					it.count
+				}
+			val newUserPose =
+				if (newDetectedState == ExerciseState.UP || newDetectedState == ExerciseState.DOWN) {
+					newDetectedState
+				} else {
+					it.userPose
+				}
+			it.copy(
+				count = newCount,
+				userPose = newUserPose,
+				detectedPose = pose
+			)
+		}
+	}
+	
+	@RequiresApi(Build.VERSION_CODES.O)
+	fun saveWorkoutResult(exerciseType: ExerciseType) {
+		viewModelScope.launch {
+			val totalCount = _uiState.value.count
+			
+			if (totalCount > 0) {
+				val recordToSave = ExerciseCollection(
+					userId = "test",
+					exerciseType = exerciseType.name,
+					count = totalCount
+				)
+				val result = exerciseRepository.addExerciseRecord(recordToSave)
+				if (result) {
+					loadInitialData()
+				} else {
+					_uiState.update { it.copy(isError = true) }
+				}
+			}
+		}
+	}
+	
+	fun onExerciseSelected(exerciseType: ExerciseType) {
+		_uiState.update {
+			it.copy(
+				selectedExercise = exerciseType,
+				showDialog = true
+			)
+		}
+	}
+	
+	fun onDialogDismiss() {
+		_uiState.update { it.copy(showDialog = false) }
+	}
+	
+	fun onDialogConfirm() {
+		_uiState.update { it.copy(showDialog = false) }
+	}
+	
+	private fun createAnalyzer(type: ExerciseType): ExerciseAnalyzer {
+		return when (type) {
+			ExerciseType.DUMBBELL_CURL -> DumbbellCurlAnalyzer(isLeftHand = false)
+			ExerciseType.SQUAT -> SquatAnalyzer()
+			ExerciseType.PUSH_UP -> PushUpAnalyzer(isLeftHand = false)
+			ExerciseType.DUMBBELL_SHOULDER_PRESS -> DumbbellShoulderPressAnalyzer(isLeftHand = false)
+		}
+	}
 }

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/ExerciseViewModel.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/ExerciseViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.WeekFields
+import kotlin.collections.map
 
 @RequiresApi(Build.VERSION_CODES.O)
 class ExerciseViewModel(
@@ -45,34 +46,24 @@ class ExerciseViewModel(
 			_uiState.update { it.copy(isLoading = true) }
 			try {
 				val exercises = exerciseRepository.getExerciseStat(userId = "test")
-				//
 				val dailyExercises = exerciseRepository.getDailyExerciseList()
 				val completedDates = exerciseRepository.getCompletedDailyExerciseDates("test")
-				
-				//
 				val totalCountsMap = exercises.associate {
-					ExerciseType.valueOf(it.exerciseType) to it.count
+					it.exerciseType to it.count
 				}
-				
-				//
 				val weeklyCountsMap = calculateWeeklyCounts(exercises)
-				val dailyCountsMap = calculateDailyCounts(exercises) // [추가]
-				
-				
+				val dailyCountsMap = calculateDailyCounts(exercises)
 				val groupedBySport = exercises.groupBy { it.exerciseType }
-				val countsMap = groupedBySport.mapNotNull { (sportName, records) ->
-					ExerciseType.valueOf(sportName).let { type ->
-						type to records.sumOf { it.count }
+				val countsMap = groupedBySport.mapValues { (_, records) ->
+					records.sumOf { it.count }
 					}
-				}.toMap()
 				val uiModelList = ExerciseType.entries.map { exerciseType ->
-					val count = countsMap[exerciseType] ?: 0
+					val count = countsMap[exerciseType]?:0
 					val weeklyCount = weeklyCountsMap[exerciseType] ?: 0
-					val dailyCount = dailyCountsMap[exerciseType] ?: 0 // [추가]
+					val dailyCount = dailyCountsMap[exerciseType] ?: 0
 					//
 					exerciseType.toUiModel(count, weeklyCount, dailyCount)
 				}
-//                    exerciseType.toUiModel(count)      }
 				_uiState.update {
 					it.copy(
 						isLoading = false,
@@ -80,7 +71,7 @@ class ExerciseViewModel(
 						
 						totalExerciseCounts = totalCountsMap,
 						weeklyExerciseCounts = weeklyCountsMap,
-						dailyExerciseCounts = dailyCountsMap, // [추가]
+						dailyExerciseCounts = dailyCountsMap,
 						completedDailyExerciseDates = completedDates,
 						
 						exerciseCounts = countsMap,
@@ -96,41 +87,24 @@ class ExerciseViewModel(
 	private fun calculateDailyCounts(exercises: List<ExerciseCollection>): Map<ExerciseType, Int> {
 		val currentDailyKey = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
 		return exercises.associate {
-			ExerciseType.valueOf(it.exerciseType) to (it.dailyCounts[currentDailyKey] ?: 0)
+			it.exerciseType to (it.dailyCounts[currentDailyKey] ?: 0)
 		}
 	}
 	
-	// [수정] 이번 주 운동 횟수 계산 로직
 	@SuppressLint("DefaultLocale")
 	private fun calculateWeeklyCounts(exercises: List<ExerciseCollection>): Map<ExerciseType, Int> {
-		// "년도-W주차" 형식의 키 생성
 		val today = LocalDate.now()
 		val weekFields = WeekFields.ISO
 		
-		// [수정] 여기도 동일하게 '주차 기준 연도'를 사용해야 합니다.
 		val weekBasedYear = today.get(weekFields.weekBasedYear())
 		val weekOfYear = today.get(weekFields.weekOfWeekBasedYear())
 		
 		val currentWeekKey = "${weekBasedYear}-W${String.format("%02d", weekOfYear)}"
 		
-		// 각 운동의 weeklyCounts 맵에서 이번 주 키에 해당하는 값을 가져옴
 		return exercises.associate {
-			ExerciseType.valueOf(it.exerciseType) to (it.weeklyCounts[currentWeekKey] ?: 0)
+			it.exerciseType to (it.weeklyCounts[currentWeekKey] ?: 0)
 		}
 	}
-//	@RequiresApi(Build.VERSION_CODES.O)
-//	private fun calculateWeeklyCounts(exercises: List<ExerciseCollection>): Map<ExerciseType, Int> {
-//		val today = LocalDate.now()
-//		// 월요일을 주의 시작으로 설정
-//		val startOfWeek = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-//		val startOfWeekMillis =
-//			startOfWeek.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
-//
-//		return exercises
-//			.filter { it.createdAt >= startOfWeekMillis } // 이번 주 기록만 필터링
-//			.groupBy { ExerciseType.valueOf(it.exerciseType) }
-//			.mapValues { (_, records) -> records.sumOf { it.count } }
-//	}
 	
 	fun initialize(exerciseType: ExerciseType) {
 		this.analyzer = createAnalyzer(exerciseType)
@@ -175,7 +149,7 @@ class ExerciseViewModel(
 			if (totalCount > 0) {
 				val recordToSave = ExerciseCollection(
 					userId = "test",
-					exerciseType = exerciseType.name,
+					exerciseType = exerciseType,
 					count = totalCount
 				)
 				val result = exerciseRepository.addExerciseRecord(recordToSave)

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/WorkOutScreen.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/exercise/WorkOutScreen.kt
@@ -1,6 +1,8 @@
 package com.cases.carefull.features.carefullcontents.routine.exercise
 
 import android.Manifest
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageAnalysis
@@ -39,6 +41,7 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 
+@RequiresApi(Build.VERSION_CODES.O)
 @androidx.annotation.OptIn(ExperimentalGetImage::class)
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable

--- a/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeScreen.kt
+++ b/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeScreen.kt
@@ -49,6 +49,9 @@ fun HomeScreen(
 	navController: NavController
 ) {
 	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+	
+	val todayExercise = uiState.dailyExercise.firstOrNull()
+	
 	val pagerState = rememberPagerState(
 		initialPage = START_PAGE,
 		pageCount = { Int.MAX_VALUE }
@@ -59,9 +62,10 @@ fun HomeScreen(
 		viewType = uiState.viewType,
 		calendarDates = uiState.calendarDates,
 		selectedDateInfo = uiState.selectedDateInfo,
-		markedDates = uiState.loggedMealDates
+		markedDates = uiState.loggedMealDates,
+		dailyExerciseCompletedDates = uiState.dailyExerciseCompletedDates
 	)
-	val todayExerciseName = uiState.dailyExercise.first().type
+//	val todayExerciseName = uiState.dailyExercise.firstOrNull()
 	
 	LaunchedEffect(pagerState) {
 		snapshotFlow { pagerState.settledPage }
@@ -124,17 +128,21 @@ fun HomeScreen(
 					targetCalories = uiState.activityMetabolism,
 					onClick = { navController.navigate(RoutineRoute.DietScreen) }
 				)
-				WorkoutInfoCard(
-					exerciseName = todayExerciseName,
-					onClick = {
-						navController.navigate(
-							RoutineRoute.WorkOutScreen(
-								exerciseType = uiState.dailyExercise.first(),
-								count = 10
+				if (todayExercise != null) {
+					WorkoutInfoCard(
+						exerciseName = todayExercise.type,
+						todayCount = uiState.todayExerciseCount,
+						goalCount = HomeViewModel.TODAY_EXERCISE_GOAL, // [추가] 목표량 전달
+						onClick = {
+							navController.navigate(
+								RoutineRoute.WorkOutScreen(
+									exerciseType = uiState.dailyExercise.first(),
+									count = 10
+								)
 							)
-						)
-					}
-				)
+						}
+					)
+				}
 			}
 		}
 	}
@@ -194,6 +202,8 @@ fun DietInfoCard(
 @Composable
 fun WorkoutInfoCard(
 	exerciseName: String,
+	todayCount: Int, // [추가]
+	goalCount: Int, // [추가]
 	onClick: () -> Unit
 ) {
 	Card(
@@ -214,11 +224,31 @@ fun WorkoutInfoCard(
 					color = Color.Gray
 				)
 				Spacer(modifier = Modifier.height(4.dp))
-				Text(
-					text = exerciseName,
-					style = MaterialTheme.typography.bodyLarge,
-					fontWeight = FontWeight.Bold
-				)
+				Row(
+					verticalAlignment = Alignment.Bottom,
+					horizontalArrangement = Arrangement.spacedBy(8.dp)
+				) {
+					Text(
+						text = exerciseName,
+						style = MaterialTheme.typography.bodyLarge,
+						fontWeight = FontWeight.Bold
+					)
+					Text(
+						text = buildAnnotatedString {
+							withStyle(
+								style = SpanStyle(
+									fontWeight = FontWeight.Bold,
+									color = MaterialTheme.colorScheme.primary
+								)
+							) {
+								append("$todayCount")
+							}
+							append(" / $goalCount 회")
+						},
+						style = MaterialTheme.typography.bodyMedium,
+						color = Color.Gray
+					)
+				}
 			}
 			Icon(
 				imageVector = Icons.AutoMirrored.Filled.ArrowForwardIos,

--- a/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeScreen.kt
+++ b/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
+import com.cases.carefull.domain.model.CalendarViewType
 import com.cases.carefull.features.carefullcommon.components.Calendar
 import com.cases.carefull.features.carefullcommon.components.CalendarState
 import com.cases.carefull.features.carefullcommon.navigation.RoutineRoute
@@ -65,7 +66,6 @@ fun HomeScreen(
 		markedDates = uiState.loggedMealDates,
 		dailyExerciseCompletedDates = uiState.dailyExerciseCompletedDates
 	)
-//	val todayExerciseName = uiState.dailyExercise.firstOrNull()
 	
 	LaunchedEffect(pagerState) {
 		snapshotFlow { pagerState.settledPage }
@@ -112,6 +112,68 @@ fun HomeScreen(
 			},
 			onGoToToday = {
 				viewModel.onGoToToday()
+			},
+			calendarFooterContent = {
+				val shouldShowDetails = uiState.viewType == CalendarViewType.MONTHLY &&
+						(uiState.selectedDateExerciseRecords.isNotEmpty() || uiState.selectedDateTotalCalories > 0)
+				
+				if (shouldShowDetails) {
+					if (uiState.selectedDateExerciseRecords.isNotEmpty()) {
+						Column {
+							Text(
+								"운동 기록",
+								fontWeight = FontWeight.Bold,
+								style = MaterialTheme.typography.titleSmall
+							)
+							Spacer(modifier = Modifier.height(4.dp))
+							uiState.selectedDateExerciseRecords.forEach { record ->
+								Row(
+									modifier = Modifier.fillMaxWidth(),
+									horizontalArrangement = Arrangement.SpaceBetween,
+									verticalAlignment = Alignment.CenterVertically
+								) {
+									Text(
+										record.name,
+										style = MaterialTheme.typography.bodyMedium
+									)
+									Text(
+										"${record.count}회",
+										style = MaterialTheme.typography.bodyMedium,
+										color = Color.Gray
+									)
+								}
+							}
+						}
+					}
+					
+					
+					// 식단 기록 섹션
+					if (uiState.selectedDateTotalCalories > 0) {
+						Column {
+							Text(
+								"식단 기록",
+								fontWeight = FontWeight.Bold,
+								style = MaterialTheme.typography.titleSmall
+							)
+							Spacer(modifier = Modifier.height(4.dp))
+							Row(
+								modifier = Modifier.fillMaxWidth(),
+								horizontalArrangement = Arrangement.SpaceBetween,
+								verticalAlignment = Alignment.CenterVertically
+							) {
+								Text(
+									"총 섭취 칼로리",
+									style = MaterialTheme.typography.bodyMedium
+								)
+								Text(
+									"${uiState.selectedDateTotalCalories} kcal",
+									style = MaterialTheme.typography.bodyMedium,
+									color = Color.Gray
+								)
+							}
+						}
+					}
+				}
 			}
 		)
 		
@@ -132,7 +194,7 @@ fun HomeScreen(
 					WorkoutInfoCard(
 						exerciseName = todayExercise.type,
 						todayCount = uiState.todayExerciseCount,
-						goalCount = HomeViewModel.TODAY_EXERCISE_GOAL, // [추가] 목표량 전달
+						goalCount = HomeViewModel.TODAY_EXERCISE_GOAL,
 						onClick = {
 							navController.navigate(
 								RoutineRoute.WorkOutScreen(
@@ -202,8 +264,8 @@ fun DietInfoCard(
 @Composable
 fun WorkoutInfoCard(
 	exerciseName: String,
-	todayCount: Int, // [추가]
-	goalCount: Int, // [추가]
+	todayCount: Int,
+	goalCount: Int,
 	onClick: () -> Unit
 ) {
 	Card(

--- a/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeUiState.kt
+++ b/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeUiState.kt
@@ -26,6 +26,8 @@ data class HomeUiState(
 	val activityMetabolism: Int = 0,
 	
 	val loggedMealDates: Set<LocalDate> = emptySet(),
+	val dailyExerciseCompletedDates: Set<LocalDate> = emptySet(),
+	val todayExerciseCount: Int = 0, // [추가]
 	val hasLoggedMealToday: Boolean = false,
 	
 	val pagerTargetPage: Int = START_PAGE

--- a/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeUiState.kt
+++ b/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeUiState.kt
@@ -3,6 +3,7 @@ package com.cases.carefull.features.carefullmainui.home
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.cases.carefull.domain.model.CalendarViewType
+import com.cases.carefull.domain.model.exercise.ExerciseRecordForDate
 import com.cases.carefull.domain.model.exercise.ExerciseType
 import java.time.LocalDate
 import java.time.YearMonth
@@ -27,8 +28,11 @@ data class HomeUiState(
 	
 	val loggedMealDates: Set<LocalDate> = emptySet(),
 	val dailyExerciseCompletedDates: Set<LocalDate> = emptySet(),
-	val todayExerciseCount: Int = 0, // [추가]
+	val todayExerciseCount: Int = 0,
 	val hasLoggedMealToday: Boolean = false,
+	
+	val selectedDateExerciseRecords: List<ExerciseRecordForDate> = emptyList(),
+	val selectedDateTotalCalories: Int = 0,
 	
 	val pagerTargetPage: Int = START_PAGE
 ) {

--- a/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeViewModel.kt
+++ b/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeViewModel.kt
@@ -5,6 +5,8 @@ import androidx.annotation.RequiresApi
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cases.carefull.domain.model.CalendarViewType
+import com.cases.carefull.domain.model.exercise.ExerciseCollection
+import com.cases.carefull.domain.model.exercise.ExerciseType
 import com.cases.carefull.domain.repository.CalendarRepository
 import com.cases.carefull.domain.repository.DietRepository
 import com.cases.carefull.domain.repository.ExerciseRepository
@@ -12,6 +14,8 @@ import com.cases.carefull.domain.util.DataResourceResult
 import com.cases.carefull.features.carefullmainui.home.HomeUiState.Companion.START_PAGE
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
@@ -19,6 +23,7 @@ import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters
 
@@ -31,15 +36,109 @@ class HomeViewModel(
 	private val _uiState = MutableStateFlow(HomeUiState())
 	val uiState = _uiState.asStateFlow()
 	
-	init {
-		observeCalendarChanges()
-		observeAllMeals()
-		refreshHomeData()
-		loadInitialData()
-		loadBmrData()
-		loadDietData()
+	companion object {
+		const val TODAY_EXERCISE_GOAL = 30
 	}
 	
+	init {
+		observeAllDataFlows()     // 모든 실시간 데이터 스트림 구독
+		observeCalendarChanges()  // UI 이벤트 관련 데이터 스트림 구독
+		loadOneTimeData()
+		
+//		loadStaticData()
+//		observeRealtimeData()
+//		observeAllMeals()
+//		observeCalendarChanges()
+//		refreshHomeData()
+//		loadBmrData()
+//		loadDietData()
+//		loadInitialData()
+	}
+	
+	private fun observeAllDataFlows() {
+		// 1. 운동 기록, 완료 날짜, 식단 기록 Flow를 하나로 합칩니다.
+		viewModelScope.launch {
+			combine(
+				exerciseRepository.getExerciseStatFlow("test"),
+				exerciseRepository.getCompletedDailyExerciseDatesFlow("test"),
+				dietRepository.getAllMeal() // 이 함수가 Flow<DataResourceResult<...>>를 반환한다고 가정
+			) { exerciseStats, completedDates, dietResult ->
+				// 3개의 Flow 중 하나라도 새로운 값을 방출하면 이 블록이 실행됩니다.
+				
+				// 식단 데이터 처리
+				val todayCalories: Int
+				val loggedMealDates: Set<LocalDate>
+				if (dietResult is DataResourceResult.Success) {
+					val mealsByDate = dietResult.data
+					todayCalories = (mealsByDate[LocalDate.now()] ?: emptyList()).sumOf { it.kcal }
+					loggedMealDates = mealsByDate.keys
+				} else {
+					todayCalories = _uiState.value.todayTotalCalories // 이전 값 유지 또는 0
+					loggedMealDates = _uiState.value.loggedMealDates // 이전 값 유지 또는 emptySet()
+				}
+				
+				// 운동 횟수 계산
+				val todayExerciseType = _uiState.value.dailyExercise.firstOrNull()
+				val todayCount = calculateTodayExerciseCount(exerciseStats, todayExerciseType)
+				
+				// 최종적으로 모든 데이터를 한 번에 업데이트
+				_uiState.update {
+					it.copy(
+						isLoading = false,
+						todayExerciseCount = todayCount,
+						dailyExerciseCompletedDates = completedDates,
+						todayTotalCalories = todayCalories,
+						loggedMealDates = loggedMealDates,
+						isError = dietResult is DataResourceResult.Error // 에러 상태 업데이트
+					)
+				}
+				
+			}.collect() // combine Flow를 수집 시작
+		}
+	}
+	
+	private fun loadOneTimeData() {
+		viewModelScope.launch {
+			// 오늘의 운동 종류 (앱 실행 시 한 번만 결정됨)
+			val dailyExercises = exerciseRepository.getDailyExerciseList()
+			_uiState.update { it.copy(dailyExercise = dailyExercises) }
+		}
+		
+		// BMR (자주 바뀌지 않음)
+		viewModelScope.launch {
+			dietRepository.getMyBmr("test").collect { bmr ->
+				if (bmr != null) {
+					_uiState.update { it.copy(activityMetabolism = bmr.activityBmr) }
+				}
+			}
+		}
+		
+		// 초기 페이지 계산 (UI와 관련 있으므로 여기에 두거나, observeCalendarChanges와 합쳐도 됨)
+		calculateAndupdateTargetPage(_uiState.value.selectedDate, _uiState.value.viewType)
+	}
+	
+	// [추가] 실시간 데이터 스트림을 구독하는 함수
+	private fun observeRealtimeData() {
+		viewModelScope.launch {
+			// 운동 기록 Flow 구독
+			exerciseRepository.getExerciseStatFlow("test").collect { allExerciseStats ->
+				val todayExerciseType = _uiState.value.dailyExercise.firstOrNull()
+				val todayCount = calculateTodayExerciseCount(allExerciseStats, todayExerciseType)
+				
+				_uiState.update {
+					it.copy(
+						isLoading = false,
+						todayExerciseCount = todayCount
+					)
+				}
+			}
+		}
+		viewModelScope.launch {
+			exerciseRepository.getCompletedDailyExerciseDatesFlow("test").collect { completedDates ->
+				_uiState.update { it.copy(dailyExerciseCompletedDates = completedDates) }
+			}
+		}
+	}
 	private fun observeCalendarChanges() {
 		viewModelScope.launch {
 			uiState.map { it.selectedDate to it.viewType }
@@ -57,6 +156,20 @@ class HomeViewModel(
 						)
 					}
 				}
+		}
+	}
+	
+	// [추가] 한 번만 로드하면 되는 데이터를 가져오는 함수
+	private fun loadStaticData() {
+		viewModelScope.launch {
+			val dailyExercises = exerciseRepository.getDailyExerciseList()
+			val completedDates = exerciseRepository.getCompletedDailyExerciseDates("test")
+			_uiState.update {
+				it.copy(
+					dailyExercise = dailyExercises,
+					dailyExerciseCompletedDates = completedDates
+				)
+			}
 		}
 	}
 	
@@ -213,22 +326,48 @@ class HomeViewModel(
 		}
 	}
 	
-	fun loadInitialData() {
-		viewModelScope.launch {
-			_uiState.update { it.copy(isLoading = true) }
-			try {
-				val dailyExercises = exerciseRepository.getDailyExerciseList()
-				_uiState.update {
-					it.copy(
-						isLoading = false,
-						dailyExercise = dailyExercises
-					)
-				}
-			} catch (e: Exception) {
-				_uiState.update { it.copy(isLoading = false, isError = true) }
-			}
-		}
+//	fun loadInitialData() {
+//		viewModelScope.launch {
+//			_uiState.update { it.copy(isLoading = true) }
+//			try {
+//				val dailyExercises = exerciseRepository.getDailyExerciseList()
+//				val completedDates = exerciseRepository.getCompletedDailyExerciseDates("test")
+//
+//				val allExerciseStats = exerciseRepository.getExerciseStat("test")
+//				val todayExerciseType = dailyExercises.firstOrNull()
+//
+//				val todayCount = calculateTodayExerciseCount(allExerciseStats, todayExerciseType)
+//
+//				_uiState.update {
+//					it.copy(
+//						isLoading = false,
+//						dailyExercise = dailyExercises,
+//						dailyExerciseCompletedDates = completedDates, // [추가] 상태 업데이트
+//						todayExerciseCount = todayCount
+//					)
+//				}
+//			} catch (e: Exception) {
+//				_uiState.update { it.copy(isLoading = false, isError = true) }
+//			}
+//		}
+//	}
+	
+	private fun calculateTodayExerciseCount(
+		stats: List<ExerciseCollection>,
+		todayExercise: ExerciseType?
+	): Int {
+		if (todayExercise == null) return 0
+		
+		// 전체 통계에서 오늘의 운동에 해당하는 기록을 찾습니다.
+		val exerciseForToday = stats.find { it.exerciseType == todayExercise.name }
+		
+		// "YYYY-MM-DD" 형식의 오늘 날짜 키를 만듭니다.
+		val dailyKey = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+		
+		// dailyCounts 맵에서 오늘 날짜 키로 횟수를 가져옵니다. 없으면 0을 반환합니다.
+		return exerciseForToday?.dailyCounts?.get(dailyKey) ?: 0
 	}
+	
 	
 	private fun loadBmrData() {
 		viewModelScope.launch {

--- a/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeViewModel.kt
+++ b/features/carefullmainui/src/main/java/com/cases/carefull/features/carefullmainui/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cases.carefull.domain.model.CalendarViewType
 import com.cases.carefull.domain.model.exercise.ExerciseCollection
+import com.cases.carefull.domain.model.exercise.ExerciseRecordForDate
 import com.cases.carefull.domain.model.exercise.ExerciseType
 import com.cases.carefull.domain.repository.CalendarRepository
 import com.cases.carefull.domain.repository.DietRepository
@@ -41,47 +42,49 @@ class HomeViewModel(
 	}
 	
 	init {
-		observeAllDataFlows()     // 모든 실시간 데이터 스트림 구독
-		observeCalendarChanges()  // UI 이벤트 관련 데이터 스트림 구독
+		observeAllDataFlows()
+		observeCalendarChanges()
 		loadOneTimeData()
-		
-//		loadStaticData()
-//		observeRealtimeData()
-//		observeAllMeals()
-//		observeCalendarChanges()
-//		refreshHomeData()
-//		loadBmrData()
-//		loadDietData()
-//		loadInitialData()
 	}
 	
 	private fun observeAllDataFlows() {
-		// 1. 운동 기록, 완료 날짜, 식단 기록 Flow를 하나로 합칩니다.
 		viewModelScope.launch {
 			combine(
 				exerciseRepository.getExerciseStatFlow("test"),
 				exerciseRepository.getCompletedDailyExerciseDatesFlow("test"),
-				dietRepository.getAllMeal() // 이 함수가 Flow<DataResourceResult<...>>를 반환한다고 가정
-			) { exerciseStats, completedDates, dietResult ->
-				// 3개의 Flow 중 하나라도 새로운 값을 방출하면 이 블록이 실행됩니다.
+				dietRepository.getAllMeal(),
+				_uiState.map { it.viewType to it.selectedDate }.distinctUntilChanged()
+			) { exerciseStats, completedDates, dietResult, (viewType, selectedDate) ->
 				
-				// 식단 데이터 처리
-				val todayCalories: Int
-				val loggedMealDates: Set<LocalDate>
-				if (dietResult is DataResourceResult.Success) {
-					val mealsByDate = dietResult.data
-					todayCalories = (mealsByDate[LocalDate.now()] ?: emptyList()).sumOf { it.kcal }
-					loggedMealDates = mealsByDate.keys
-				} else {
-					todayCalories = _uiState.value.todayTotalCalories // 이전 값 유지 또는 0
-					loggedMealDates = _uiState.value.loggedMealDates // 이전 값 유지 또는 emptySet()
-				}
+				val mealsByDate =
+					if (dietResult is DataResourceResult.Success) dietResult.data else emptyMap()
+				val todayCalories = (mealsByDate[LocalDate.now()] ?: emptyList()).sumOf { it.kcal }
+				val loggedMealDates = mealsByDate.keys
 				
-				// 운동 횟수 계산
 				val todayExerciseType = _uiState.value.dailyExercise.firstOrNull()
 				val todayCount = calculateTodayExerciseCount(exerciseStats, todayExerciseType)
 				
-				// 최종적으로 모든 데이터를 한 번에 업데이트
+				val today = LocalDate.now()
+				if (todayCount >= TODAY_EXERCISE_GOAL && !completedDates.contains(today)) {
+					viewModelScope.launch {
+						exerciseRepository.markDailyExerciseAsCompleted("test", today)
+					}
+				}
+				val exerciseRecordsForDate: List<ExerciseRecordForDate>
+				val totalCaloriesForDate: Int
+				if (viewType == CalendarViewType.MONTHLY) {
+					val dateKey = selectedDate.format(DateTimeFormatter.ISO_LOCAL_DATE)
+					
+					exerciseRecordsForDate = exerciseStats.mapNotNull { stat ->
+						stat.dailyCounts[dateKey]?.let { count ->
+							ExerciseRecordForDate(name = stat.exerciseType.type, count = count)
+						}
+					}
+					totalCaloriesForDate = mealsByDate[selectedDate]?.sumOf { it.kcal } ?: 0
+				} else {
+					exerciseRecordsForDate = emptyList()
+					totalCaloriesForDate = 0
+				}
 				_uiState.update {
 					it.copy(
 						isLoading = false,
@@ -89,22 +92,20 @@ class HomeViewModel(
 						dailyExerciseCompletedDates = completedDates,
 						todayTotalCalories = todayCalories,
 						loggedMealDates = loggedMealDates,
-						isError = dietResult is DataResourceResult.Error // 에러 상태 업데이트
+						isError = dietResult is DataResourceResult.Error,
+						selectedDateExerciseRecords = exerciseRecordsForDate,
+						selectedDateTotalCalories = totalCaloriesForDate
 					)
 				}
-				
-			}.collect() // combine Flow를 수집 시작
+			}.collect()
 		}
 	}
 	
 	private fun loadOneTimeData() {
 		viewModelScope.launch {
-			// 오늘의 운동 종류 (앱 실행 시 한 번만 결정됨)
 			val dailyExercises = exerciseRepository.getDailyExerciseList()
 			_uiState.update { it.copy(dailyExercise = dailyExercises) }
 		}
-		
-		// BMR (자주 바뀌지 않음)
 		viewModelScope.launch {
 			dietRepository.getMyBmr("test").collect { bmr ->
 				if (bmr != null) {
@@ -112,33 +113,9 @@ class HomeViewModel(
 				}
 			}
 		}
-		
-		// 초기 페이지 계산 (UI와 관련 있으므로 여기에 두거나, observeCalendarChanges와 합쳐도 됨)
 		calculateAndupdateTargetPage(_uiState.value.selectedDate, _uiState.value.viewType)
 	}
 	
-	// [추가] 실시간 데이터 스트림을 구독하는 함수
-	private fun observeRealtimeData() {
-		viewModelScope.launch {
-			// 운동 기록 Flow 구독
-			exerciseRepository.getExerciseStatFlow("test").collect { allExerciseStats ->
-				val todayExerciseType = _uiState.value.dailyExercise.firstOrNull()
-				val todayCount = calculateTodayExerciseCount(allExerciseStats, todayExerciseType)
-				
-				_uiState.update {
-					it.copy(
-						isLoading = false,
-						todayExerciseCount = todayCount
-					)
-				}
-			}
-		}
-		viewModelScope.launch {
-			exerciseRepository.getCompletedDailyExerciseDatesFlow("test").collect { completedDates ->
-				_uiState.update { it.copy(dailyExerciseCompletedDates = completedDates) }
-			}
-		}
-	}
 	private fun observeCalendarChanges() {
 		viewModelScope.launch {
 			uiState.map { it.selectedDate to it.viewType }
@@ -159,73 +136,13 @@ class HomeViewModel(
 		}
 	}
 	
-	// [추가] 한 번만 로드하면 되는 데이터를 가져오는 함수
-	private fun loadStaticData() {
-		viewModelScope.launch {
-			val dailyExercises = exerciseRepository.getDailyExerciseList()
-			val completedDates = exerciseRepository.getCompletedDailyExerciseDates("test")
-			_uiState.update {
-				it.copy(
-					dailyExercise = dailyExercises,
-					dailyExerciseCompletedDates = completedDates
-				)
-			}
-		}
-	}
-	
-	private fun observeAllMeals() {
-		viewModelScope.launch {
-			dietRepository.getAllMeal().collect { result ->
-				_uiState.update { it.copy(isLoading = true) }
-				when (result) {
-					is DataResourceResult.Success -> {
-						val mealsByDate = result.data
-						val today = LocalDate.now()
-						val todayMeals = mealsByDate[today] ?: emptyList()
-						val todayCalories = todayMeals.sumOf { it.kcal }
-						val datesWithLoggedMeals = mealsByDate.keys
-						
-						_uiState.update {
-							it.copy(
-								isLoading = false,
-								isError = false,
-								todayTotalCalories = todayCalories,
-								loggedMealDates = datesWithLoggedMeals
-							)
-						}
-					}
-					
-					is DataResourceResult.Error -> {
-						_uiState.update { it.copy(isLoading = false, isError = true) }
-					}
-					
-					is DataResourceResult.Loading -> {
-					}
-				}
-			}
-		}
-	}
-	
-	fun refreshHomeData() {
-		viewModelScope.launch {
-			dietRepository.getMyBmr("test").collect { bmr ->
-				if (bmr != null) {
-					_uiState.update {
-						it.copy(activityMetabolism = bmr.activityBmr)
-					}
-				}
-			}
-		}
-		calculateAndupdateTargetPage(_uiState.value.selectedDate, _uiState.value.viewType)
-	}
-	
 	private fun calculateAndupdateTargetPage(selectedDate: LocalDate, viewType: CalendarViewType) {
 		val targetPage = if (viewType == CalendarViewType.MONTHLY) {
 			START_PAGE + ChronoUnit.MONTHS.between(
 				YearMonth.from(LocalDate.now()),
 				YearMonth.from(selectedDate)
 			).toInt()
-		} else { // WEEKLY
+		} else {
 			val startOfReferenceWeek =
 				LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
 			val startOfSelectedDateWeek =
@@ -256,7 +173,6 @@ class HomeViewModel(
 			val originalSelectedDay = _uiState.value.selectedDate.dayOfMonth
 			val targetYearMonth = YearMonth.from(LocalDate.now()).plusMonths(pageOffset)
 			val lastDayOfTargetMonth = targetYearMonth.lengthOfMonth()
-			// 예: 31일 -> 28일 자동 변경, 29일 -> 29일
 			val dayToSet = minOf(originalSelectedDay, lastDayOfTargetMonth)
 			targetYearMonth.atDay(dayToSet)
 			
@@ -326,96 +242,13 @@ class HomeViewModel(
 		}
 	}
 	
-//	fun loadInitialData() {
-//		viewModelScope.launch {
-//			_uiState.update { it.copy(isLoading = true) }
-//			try {
-//				val dailyExercises = exerciseRepository.getDailyExerciseList()
-//				val completedDates = exerciseRepository.getCompletedDailyExerciseDates("test")
-//
-//				val allExerciseStats = exerciseRepository.getExerciseStat("test")
-//				val todayExerciseType = dailyExercises.firstOrNull()
-//
-//				val todayCount = calculateTodayExerciseCount(allExerciseStats, todayExerciseType)
-//
-//				_uiState.update {
-//					it.copy(
-//						isLoading = false,
-//						dailyExercise = dailyExercises,
-//						dailyExerciseCompletedDates = completedDates, // [추가] 상태 업데이트
-//						todayExerciseCount = todayCount
-//					)
-//				}
-//			} catch (e: Exception) {
-//				_uiState.update { it.copy(isLoading = false, isError = true) }
-//			}
-//		}
-//	}
-	
 	private fun calculateTodayExerciseCount(
 		stats: List<ExerciseCollection>,
 		todayExercise: ExerciseType?
 	): Int {
 		if (todayExercise == null) return 0
-		
-		// 전체 통계에서 오늘의 운동에 해당하는 기록을 찾습니다.
-		val exerciseForToday = stats.find { it.exerciseType == todayExercise.name }
-		
-		// "YYYY-MM-DD" 형식의 오늘 날짜 키를 만듭니다.
+		val exerciseForToday = stats.find { it.exerciseType == todayExercise }
 		val dailyKey = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
-		
-		// dailyCounts 맵에서 오늘 날짜 키로 횟수를 가져옵니다. 없으면 0을 반환합니다.
 		return exerciseForToday?.dailyCounts?.get(dailyKey) ?: 0
-	}
-	
-	
-	private fun loadBmrData() {
-		viewModelScope.launch {
-			dietRepository.getMyBmr("test").collect { bmr ->
-				if (bmr != null) {
-					_uiState.update {
-						it.copy(activityMetabolism = bmr.activityBmr)
-					}
-				}
-			}
-		}
-	}
-	
-	private fun loadDietData() {
-		viewModelScope.launch {
-			_uiState.update { it.copy(isLoading = true) }
-			dietRepository.getAllMeal().collect { result ->
-				_uiState.update { it.copy(isLoading = true) }
-				when (result) {
-					is DataResourceResult.Success -> {
-						val meals = result.data
-						val today = LocalDate.now()
-						val todayMeals = meals[today] ?: emptyList()
-						val todayCalories = todayMeals.sumOf { it.kcal }
-						val datesWithLoggedMeals = meals.keys
-						_uiState.update {
-							it.copy(
-								isLoading = false,
-								isError = false,
-								todayTotalCalories = todayCalories,
-								loggedMealDates = datesWithLoggedMeals
-							)
-						}
-					}
-					
-					is DataResourceResult.Error -> {
-						_uiState.update {
-							it.copy(isLoading = false, isError = true)
-						}
-					}
-					
-					is DataResourceResult.Loading -> {
-						_uiState.update {
-							it.copy(isLoading = true)
-						}
-					}
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION
📝 작업 내용
---
- 오늘의 운동 완료시 달력에 기록
- 종목별 일일/주간/누적 운동 횟수 구분하여 기록 저장

🗞️ 기타
---
- 주간 운동 횟수를 통해 랭킹탭 순위를 정할 예정 

#4