### PR TITLE
feat: 검색바 공용 컴포넌트 구현

### DIFF
--- a/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/SearchBar.kt
+++ b/features/carefullcommon/src/main/java/com/cases/carefull/features/carefullcommon/components/SearchBar.kt
@@ -1,0 +1,175 @@
+package com.cases.carefull.features.carefullcommon.components
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cases.carefull.features.carefullcommon.theme.CarefullTheme
+
+@Composable
+fun SearchBar(
+    modifier: Modifier,
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onSearch: () -> Unit,
+    placeholder: String? = null,
+    label: String? = null,
+    buttonIcon: ImageVector = Icons.Default.Search
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+    val context = LocalContext.current
+    Column(modifier = modifier) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = onQueryChange,
+                textStyle = MaterialTheme.typography.bodyLarge,
+                label = if (label != null) {
+                    { Text(text = label) }
+                } else null,
+                placeholder = {
+                    if (placeholder != null) {
+                        Text(text = placeholder)
+                    }
+                },
+                modifier = Modifier.weight(1f),
+                singleLine = true,
+                trailingIcon = {
+                    if (query.isNotBlank()) {
+                        IconButton(onClick = { onQueryChange("") }) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = "텍스트 삭제"
+                            )
+                        }
+                    }
+                },
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(
+                    onSearch = {
+                        onSearch()
+                        keyboardController?.hide()
+                    }
+                ),
+                shape = RoundedCornerShape(16.dp),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.White,
+                    unfocusedContainerColor = Color.White,
+                    disabledContainerColor = Color.White,
+                    unfocusedIndicatorColor = MaterialTheme.colorScheme.primary
+                )
+            )
+            if (query.isNotBlank()) {
+                IconButton(
+                    onClick = {
+                        onSearch()
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+
+                    },
+                    modifier = Modifier.padding(start = 4.dp)
+                ) {
+                    Icon(
+                        imageVector = buttonIcon,
+                        contentDescription = "전송",
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            } else {
+                IconButton(
+                    onClick = {
+                        Toast.makeText(context, "텍스트를 입력하세요", Toast.LENGTH_SHORT).show()
+                    },
+                    modifier = Modifier.padding(start = 4.dp)
+                ) {
+                    Icon(
+                        imageVector = buttonIcon,
+                        contentDescription = "텍스트 없음",
+                        tint = Color.LightGray
+                    )
+                }
+            }
+        }
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+private fun SearchBarPreview_Empty() {
+    var text by remember { mutableStateOf("") }
+
+    CarefullTheme {
+        SearchBar(
+            modifier = Modifier,
+            query = text,
+            onQueryChange = { text = it },
+            onSearch = { },
+            placeholder = "음식을 검색하세요",
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SearchBarPreview_Filled() {
+    var text by remember { mutableStateOf("닭가슴살") }
+
+    CarefullTheme {
+        SearchBar(
+            modifier = Modifier,
+            query = text,
+            onQueryChange = { text = it },
+            onSearch = { },
+            placeholder = "음식을 검색하세요",
+            label = "음식 검색",
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SearchBarPreview_Chatbot() {
+    var text by remember { mutableStateOf("머리가 아파요") }
+    CarefullTheme {
+        SearchBar(
+            modifier = Modifier,
+            query = text,
+            onQueryChange = { text = it },
+            onSearch = { },
+            placeholder = "증상을 물어보세요",
+            buttonIcon = Icons.AutoMirrored.Filled.Send,
+        )
+    }
+}

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/chatbot/ChatbotScreen.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/chatbot/ChatbotScreen.kt
@@ -10,17 +10,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material3.AssistChip
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,14 +26,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.cases.carefull.chatbot.ChatBotViewModel
+import com.cases.carefull.features.carefullcommon.components.SearchBar
 import com.cases.carefull.features.carefullcommon.navigation.DiagnosisRoute
 
 @Composable
@@ -50,9 +44,6 @@ fun ChatBotScreen(
 
     var userInput by remember { mutableStateOf("") }
 
-    val keyboardController = LocalSoftwareKeyboardController.current
-    val focusManager = LocalFocusManager.current
-
     LaunchedEffect(Unit) {
         viewModel.navigationEvent.collect { event ->
             when (event) {
@@ -63,6 +54,7 @@ fun ChatBotScreen(
                     )
                     navController.navigate(destination)
                 }
+
                 is ChatNavigationEvent.ToDiseaseInfo -> {
                     Log.d("Navigation", "Navigate to Disease Info for: ${event.diseaseName}")
                 }
@@ -94,37 +86,17 @@ fun ChatBotScreen(
                 )
             }
         }
-
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            OutlinedTextField(
-                modifier = Modifier.weight(1f),
-                value = userInput,
-                onValueChange = { userInput = it },
-                placeholder = { Text("증상을 입력하세요") },
-                shape = RoundedCornerShape(24.dp)
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            IconButton(
-                onClick = {
-                    if (userInput.isNotBlank()) {
-                        viewModel.sendMessage(userInput)
-                        userInput = ""
-
-                        keyboardController?.hide()
-                        focusManager.clearFocus()
-                    }
-                }
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.Send,
-                    tint = MaterialTheme.colorScheme.primary,
-                    contentDescription = "전송"
-                )
-            }
-        }
+        SearchBar(
+            modifier = Modifier,
+            query = userInput,
+            onQueryChange = { userInput = it },
+            onSearch = {
+                viewModel.sendMessage(userInput)
+                userInput = ""
+            },
+            placeholder = "증상을 입력하세요",
+            buttonIcon = Icons.AutoMirrored.Filled.Send
+        )
     }
 }
 
@@ -135,8 +107,10 @@ fun ChatBubble(
     onDiseaseClick: (String) -> Unit
 ) {
     val alignment = if (message.isUser) Alignment.CenterEnd else Alignment.CenterStart
-    val bgColor = if (message.isUser) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
-    val textColor = if (message.isUser) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface
+    val bgColor =
+        if (message.isUser) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant
+    val textColor =
+        if (message.isUser) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface
 
     Box(
         modifier = Modifier.fillMaxWidth(),

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/disease/DiseaseSearchScreen.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/disease/DiseaseSearchScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.cases.carefull.features.carefullcommon.theme.CarefullTheme
 import com.cases.carefull.domain.model.DiseaseInfo
+import com.cases.carefull.features.carefullcommon.components.SearchBar
 
 private val sampleDiseaseData = listOf(
     DiseaseInfo("고혈압", "고혈압은 혈압이 높은 상태입니다."),
@@ -52,51 +53,24 @@ private val sampleDiseaseData = listOf(
 
 @Composable
 fun DiseaseSearchScreen() {
-    var query by remember { mutableStateOf(TextFieldValue("")) }
+    var query by remember { mutableStateOf("") }
+//    var query by remember { mutableStateOf(TextFieldValue("")) }
     var searchResult by remember { mutableStateOf<DiseaseInfo?>(null) }
     val recentSearches = remember { mutableStateListOf<String>() }
     val context = LocalContext.current
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        SearchBar(
+            modifier = Modifier,
+            query = query,
+            onQueryChange = { query = it },
+            onSearch = {
+                val input = query
 
-        // 검색 입력창
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .background(Color(0xFFF5F5F5), RoundedCornerShape(24.dp))
-                .padding(horizontal = 16.dp, vertical = 8.dp)
-                .fillMaxWidth()
-        ) {
-            Icon(imageVector = Icons.Default.PhotoCamera, contentDescription = "카메라")
-
-            Spacer(modifier = Modifier.width(8.dp))
-
-            TextField(
-                value = query,
-                onValueChange = { query = it },
-                placeholder = { Text("무엇이든 물어보세요") },
-                singleLine = true,
-                modifier = Modifier.weight(1f),
-                colors = TextFieldDefaults.colors(
-                    unfocusedIndicatorColor = Color.Transparent,
-                    focusedIndicatorColor = Color.Transparent,
-                    disabledIndicatorColor = Color.Transparent,
-                    errorIndicatorColor = Color.Transparent
-                )
-            )
-
-            if (query.text.isNotEmpty()) {
-                IconButton(onClick = { query = TextFieldValue("") }) {
-                    Icon(imageVector = Icons.Default.Cancel, contentDescription = "지우기")
-                }
-            }
-
-            IconButton(onClick = {
-                val input = query.text.trim()
-                if (input.isEmpty()) {
-                    Toast.makeText(context, "검색어를 입력하세요", Toast.LENGTH_SHORT).show()
-                    return@IconButton
-                }
                 if (!recentSearches.contains(input)) {
                     recentSearches.add(0, input)
                     if (recentSearches.size > 10) recentSearches.removeAt(recentSearches.lastIndex)
@@ -105,10 +79,59 @@ fun DiseaseSearchScreen() {
                 if (searchResult == null) {
                     Toast.makeText(context, "검색 결과가 없습니다.", Toast.LENGTH_SHORT).show()
                 }
-            }) {
-                Icon(imageVector = Icons.Default.Search, contentDescription = "검색")
-            }
-        }
+            },
+            placeholder = "무엇이든 물어보세요",
+        )
+//         검색 입력창
+//        Row(
+//            verticalAlignment = Alignment.CenterVertically,
+//            modifier = Modifier
+//                .background(Color(0xFFF5F5F5), RoundedCornerShape(24.dp))
+//                .padding(horizontal = 16.dp, vertical = 8.dp)
+//                .fillMaxWidth()
+//        ) {
+//            Icon(imageVector = Icons.Default.PhotoCamera, contentDescription = "카메라")
+//
+//            Spacer(modifier = Modifier.width(8.dp))
+//
+//            TextField(
+//                value = query,
+//                onValueChange = { query = it },
+//                placeholder = { Text("무엇이든 물어보세요") },
+//                singleLine = true,
+//                modifier = Modifier.weight(1f),
+//                colors = TextFieldDefaults.colors(
+//                    unfocusedIndicatorColor = Color.Transparent,
+//                    focusedIndicatorColor = Color.Transparent,
+//                    disabledIndicatorColor = Color.Transparent,
+//                    errorIndicatorColor = Color.Transparent
+//                )
+//            )
+//
+//            if (query.text.isNotEmpty()) {
+//                IconButton(onClick = { query = TextFieldValue("") }) {
+//                    Icon(imageVector = Icons.Default.Cancel, contentDescription = "지우기")
+//                }
+//            }
+//
+//            IconButton(onClick = {
+//                val input = query.text.trim()
+//                if (input.isEmpty()) {
+//                    Toast.makeText(context, "검색어를 입력하세요", Toast.LENGTH_SHORT).show()
+//                    return@IconButton
+//                }
+//                if (!recentSearches.contains(input)) {
+//                    recentSearches.add(0, input)
+//                    if (recentSearches.size > 10) recentSearches.removeAt(recentSearches.lastIndex)
+//                }
+//                searchResult = sampleDiseaseData.find { it.name == input }
+//                if (searchResult == null) {
+//                    Toast.makeText(context, "검색 결과가 없습니다.", Toast.LENGTH_SHORT).show()
+//                }
+//            }) {
+//                Icon(imageVector = Icons.Default.Search, contentDescription = "검색")
+//            }
+//        }
 
         Spacer(modifier = Modifier.height(24.dp))
 
@@ -132,14 +155,19 @@ fun DiseaseSearchScreen() {
         if (recentSearches.isEmpty()) {
             Text("검색 기록이 없습니다.", color = Color.Gray)
         } else {
-            LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 160.dp)) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 160.dp)
+            ) {
                 items(recentSearches) { item ->
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = 8.dp)
                             .clickable {
-                                query = TextFieldValue(item)
+                                query = item
+//                                query = TextFieldValue(item)
                                 searchResult = sampleDiseaseData.find { it.name == item }
                             },
                         horizontalArrangement = Arrangement.SpaceBetween,

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/hospital/HospitalSearchScreen.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/hospital/HospitalSearchScreen.kt
@@ -60,6 +60,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.cases.carefull.features.carefullcommon.components.SearchBar
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraAnimation
 import com.naver.maps.map.CameraPosition
@@ -93,8 +94,9 @@ fun HospitalSearchScreen(
     val locationPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions(),
         onResult = { permissions ->
-            val isGranted = permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false) ||
-                    permissions.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false)
+            val isGranted =
+                permissions.getOrDefault(Manifest.permission.ACCESS_FINE_LOCATION, false) ||
+                        permissions.getOrDefault(Manifest.permission.ACCESS_COARSE_LOCATION, false)
 
             if (isGranted) {
                 viewModel.loadCurrentLocationForSearch { location ->
@@ -119,7 +121,10 @@ fun HospitalSearchScreen(
 
     LaunchedEffect(Unit) {
         locationPermissionLauncher.launch(
-            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
         )
     }
 
@@ -221,9 +226,17 @@ fun HospitalSearchScreen(
                                     }
                                     .padding(horizontal = 24.dp, vertical = 16.dp)
                             ) {
-                                Text(hospital.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                                Text(
+                                    hospital.name,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.Bold
+                                )
                                 Spacer(modifier = Modifier.height(10.dp))
-                                Text(hospital.address, style = MaterialTheme.typography.bodyMedium, color = Color.Gray)
+                                Text(
+                                    hospital.address,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = Color.Gray
+                                )
                             }
                             HorizontalDivider(
                                 modifier = Modifier.padding(horizontal = 24.dp),
@@ -270,6 +283,21 @@ fun HospitalSearchScreen(
                     .fillMaxWidth()
                     .align(Alignment.TopCenter)
             ) {
+
+//                SearchBar(
+//                    modifier = Modifier
+//                        .fillMaxWidth()
+//                        .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 0.dp),
+//                    query = uiState.searchQuery,
+//                    onQueryChange = viewModel::onSearchQueryChanged,
+//                    onSearch = {
+//                        naverMap?.cameraPosition?.target?.let { center ->
+//                            viewModel.searchHospitals(center.latitude, center.longitude)
+//                        }
+//                    },
+//                    placeholder = "병원명을 입력해주세요",
+//                )
+
                 // 검색창
                 TextField(
                     value = uiState.searchQuery,

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/medicine/MedicineSearchScreen.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/diagnosis/medicine/MedicineSearchScreen.kt
@@ -45,29 +45,37 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cases.carefull.domain.model.MedicineItem
 import com.cases.carefull.domain.model.diet.RecentMealSearch
+import com.cases.carefull.features.carefullcommon.components.SearchBar
 
 @Composable
 fun MedicineSearchScreen(
-	viewModel: MedicineViewModel = hiltViewModel(),
-	onNavigateToMedicineInfo: () -> Unit
+    viewModel: MedicineViewModel = hiltViewModel(),
+    onNavigateToMedicineInfo: () -> Unit
 ) {
-	val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-	
-	Column(
-		modifier = Modifier
-			.fillMaxSize()
-			.padding(
-				top = 16.dp,
-				start = 16.dp,
-				end = 16.dp
-			)
-	) {
-		Row(
-			verticalAlignment = Alignment.CenterVertically,
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(horizontal = 8.dp)
-		) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        SearchBar(
+            modifier = Modifier,
+            query = uiState.searchQuery,
+            onQueryChange = { newQuery ->
+                viewModel.onQueryChange(newQuery)
+            },
+            onSearch = { viewModel.addRecentSearch(uiState.searchQuery) },
+            placeholder = "약 이름을 검색하세요",
+            label = "약 검색",
+        )
+
+//		Row(
+//			verticalAlignment = Alignment.CenterVertically,
+//			modifier = Modifier
+//				.fillMaxWidth()
+//				.padding(horizontal = 8.dp)
+//		) {
 //			// 왼쪽 카메라 아이콘
 //			IconButton(onClick = { /* TODO: 카메라 기능 */ }) {
 //				Icon(
@@ -77,15 +85,8 @@ fun MedicineSearchScreen(
 //			}
 //
 //			Spacer(modifier = Modifier.width(8.dp))
-			MedicineSearchBar(
-				value = uiState.searchQuery,
-				onValueChange = { newQuery ->
-					viewModel.onQueryChange(newQuery)
-				},
-				onSearch = { viewModel.addRecentSearch(uiState.searchQuery) }
-			)
-		}
-
+//		}
+//
 //			TextField(
 //				value = uiState.searchQuery,
 //				onValueChange = { newQuery ->
@@ -116,104 +117,104 @@ fun MedicineSearchScreen(
 //			}
 //		}
 //		Spacer(modifier = Modifier.height(24.dp))
-		
-		if (uiState.searchQuery.isEmpty()) {
-			RecentSearchSection(
-				recentSearches = uiState.recentSearches,
-				onSearch = { searchTerm ->
-					viewModel.onQueryChange(searchTerm)
-				},
-				onRemove = viewModel::removeRecentSearch,
-				onClearAll = viewModel::clearRecentSearches
-			)
-		} else {
-			if (uiState.isLoading) {
-				Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-					CircularProgressIndicator()
-				}
-			}
-			
-			if (uiState.errorMessage != null) {
-				Box(
-					modifier = Modifier.fillMaxSize(),
-					contentAlignment = Alignment.Center
-				) {
-					Text("에러가 발생했습니다: ${uiState.errorMessage}", color = Color.Red)
-				}
-			} else {
-				SearchResultSection(
-					searchResults = uiState.searchResult,
-					onItemClick = { medicineItem ->
-						viewModel.setSelectedItem(medicineItem)
-						onNavigateToMedicineInfo()
-					}
-				)
-			}
-		}
-	}
+
+        if (uiState.searchQuery.isEmpty()) {
+            RecentSearchSection(
+                recentSearches = uiState.recentSearches,
+                onSearch = { searchTerm ->
+                    viewModel.onQueryChange(searchTerm)
+                },
+                onRemove = viewModel::removeRecentSearch,
+                onClearAll = viewModel::clearRecentSearches
+            )
+        } else {
+            if (uiState.isLoading) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            if (uiState.errorMessage != null) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("에러가 발생했습니다: ${uiState.errorMessage}", color = Color.Red)
+                }
+            } else {
+                SearchResultSection(
+                    searchResults = uiState.searchResult,
+                    onItemClick = { medicineItem ->
+                        viewModel.setSelectedItem(medicineItem)
+                        onNavigateToMedicineInfo()
+                    }
+                )
+            }
+        }
+    }
 }
 
 @Composable
 private fun RecentSearchSection(
-	recentSearches: List<String>,
-	onSearch: (String) -> Unit,
-	onRemove: (String) -> Unit,
-	onClearAll: () -> Unit
+    recentSearches: List<String>,
+    onSearch: (String) -> Unit,
+    onRemove: (String) -> Unit,
+    onClearAll: () -> Unit
 ) {
-	Column(
-		modifier = Modifier
-			.fillMaxWidth()
-			.padding(horizontal = 12.dp),
-		horizontalAlignment = Alignment.CenterHorizontally
-	) {
-		if (recentSearches.isEmpty()) {
-			Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-				Text("최근 검색 기록이 없습니다.", color = Color.Gray)
-			}
-		} else {
-			Row(
-				verticalAlignment = Alignment.CenterVertically
-			) {
-				Text(
-					"최근 검색",
-					style = MaterialTheme.typography.bodyMedium
-				)
-				Spacer(modifier = Modifier.weight(1f))
-				TextButton(
-					onClick = { onClearAll() },
-					contentPadding = PaddingValues(0.dp)
-				) {
-					Text(
-						"모두 삭제하기",
-						style = MaterialTheme.typography.bodySmall,
-						color = Color.Gray
-					)
-				}
-			}
-			HorizontalDivider(
-				modifier = Modifier.padding(vertical = 1.dp),
-				color = Color.Black
-			)
-			
-			
-			LazyColumn(modifier = Modifier.fillMaxWidth()) {
-				items(recentSearches) { term ->
-					Row(
-						modifier = Modifier
-							.fillMaxWidth()
-							.clickable { onSearch(term) }
-							.padding(vertical = 12.dp),
-						verticalAlignment = Alignment.CenterVertically
-					) {
-						Text(term, modifier = Modifier.weight(1f), fontSize = 16.sp)
-						IconButton(onClick = { onRemove(term) }, modifier = Modifier.size(24.dp)) {
-							Icon(Icons.Default.Close, contentDescription = "삭제", tint = Color.Gray)
-						}
-					}
-				}
-			}
-		}
-	}
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (recentSearches.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("최근 검색 기록이 없습니다.", color = Color.Gray)
+            }
+        } else {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "최근 검색",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                TextButton(
+                    onClick = { onClearAll() },
+                    contentPadding = PaddingValues(0.dp)
+                ) {
+                    Text(
+                        "모두 삭제하기",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.Gray
+                    )
+                }
+            }
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 1.dp),
+                color = Color.Black
+            )
+
+
+            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                items(recentSearches) { term ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onSearch(term) }
+                            .padding(vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(term, modifier = Modifier.weight(1f), fontSize = 16.sp)
+                        IconButton(onClick = { onRemove(term) }, modifier = Modifier.size(24.dp)) {
+                            Icon(Icons.Default.Close, contentDescription = "삭제", tint = Color.Gray)
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 
@@ -260,187 +261,129 @@ private fun RecentSearchSection(
 
 @Composable
 private fun SearchResultSection(
-	searchResults: List<MedicineItem>,
-	onItemClick: (MedicineItem) -> Unit
+    searchResults: List<MedicineItem>,
+    onItemClick: (MedicineItem) -> Unit
 ) {
-	if (searchResults.isNotEmpty()) {
-		Text("검색 결과", style = MaterialTheme.typography.titleMedium)
-		Spacer(modifier = Modifier.height(8.dp))
-		
-		LazyColumn(modifier = Modifier.fillMaxSize()) {
-			items(searchResults) { item ->
-				OutlinedCard(
-					border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
-					modifier = Modifier
-						.fillMaxWidth()
-						.padding(vertical = 4.dp)
-						.clickable {
-							onItemClick(item)
-						},
-					elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
-					colors = CardDefaults.cardColors(containerColor = Color.White),
-				) {
-					Column(Modifier.padding(16.dp)) {
-						Text(item.itemName ?: "정보 없음", style = MaterialTheme.typography.titleMedium)
-						Spacer(Modifier.height(4.dp))
-						Text(
-							text = item.efcyQesitm ?: "",
-							maxLines = 3,
-							overflow = TextOverflow.Ellipsis,
-							style = MaterialTheme.typography.bodyMedium,
-							color = MaterialTheme.colorScheme.onSurface
-						)
-					}
-				}
-			}
-		};
-	} else {
-		Text("검색 결과가 없습니다.", color = Color.Gray, modifier = Modifier.padding(top = 16.dp))
-	}
-}
+    if (searchResults.isNotEmpty()) {
+        Text("검색 결과", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
 
-@Composable
-fun MedicineSearchBar(
-	value: String,
-	onValueChange: (String) -> Unit,
-	onSearch: () -> Unit,
-	modifier: Modifier = Modifier
-) {
-	val keyboardController = LocalSoftwareKeyboardController.current
-	Row(
-		modifier = modifier.fillMaxWidth(),
-		verticalAlignment = Alignment.CenterVertically
-	) {
-		OutlinedTextField(
-			value = value,
-			onValueChange = onValueChange,
-			textStyle = MaterialTheme.typography.bodyLarge,
-			label = { Text("약 검색") },
-			modifier = Modifier.weight(1f),
-			singleLine = true,
-			placeholder = { Text("약 이름을 입력하세요", color = Color.Gray) },
-//			leadingIcon = {
-//				Icon(
-//					imageVector = Icons.Default.Search,
-//					contentDescription = "검색 아이콘"
-//				)
-//			},
-			trailingIcon = {
-				if (value.isNotBlank()) {
-					IconButton(onClick = { onValueChange("") }) {
-						Icon(
-							imageVector = Icons.Default.Close,
-							contentDescription = "입력 초기화"
-						)
-					}
-				}
-			},
-			keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-			keyboardActions = KeyboardActions(onSearch = {
-				onSearch()
-				keyboardController?.hide()
-			}
-			),
-			shape = RoundedCornerShape(16.dp)
-		)
-		IconButton(
-			modifier = Modifier.padding(top = 10.dp),
-			onClick = {
-				onSearch()
-				keyboardController?.hide()
-			}) {
-			Icon(
-				imageVector = Icons.Default.Search,
-				contentDescription = "검색 아이콘"
-			)
-		}
-	}
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(searchResults) { item ->
+                OutlinedCard(
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp)
+                        .clickable {
+                            onItemClick(item)
+                        },
+                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+                    colors = CardDefaults.cardColors(containerColor = Color.White),
+                ) {
+                    Column(Modifier.padding(16.dp)) {
+                        Text(item.itemName ?: "정보 없음", style = MaterialTheme.typography.titleMedium)
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            text = item.efcyQesitm ?: "",
+                            maxLines = 3,
+                            overflow = TextOverflow.Ellipsis,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+            }
+        };
+    } else {
+        Text("검색 결과가 없습니다.", color = Color.Gray, modifier = Modifier.padding(top = 16.dp))
+    }
 }
 
 @Composable
 fun RecentMedicineSearchesSection(
-	searches: List<RecentMealSearch>,
-	onDeleteAllRecentMealSearches: () -> Unit,
-	onItemClick: (String) -> Unit,
-	onItemDelete: (RecentMealSearch) -> Unit
+    searches: List<RecentMealSearch>,
+    onDeleteAllRecentMealSearches: () -> Unit,
+    onItemClick: (String) -> Unit,
+    onItemDelete: (RecentMealSearch) -> Unit
 ) {
-	if (searches.isEmpty()) {
-		Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-			Text("최근 검색 기록이 없습니다.", color = Color.Gray)
-		}
-	} else {
-		Column(
-			modifier = Modifier
-				.fillMaxWidth()
-				.padding(horizontal = 12.dp),
-			horizontalAlignment = Alignment.CenterHorizontally
-		) {
-			Row(
-				verticalAlignment = Alignment.CenterVertically
-			) {
-				Text(
-					"최근 검색",
-					style = MaterialTheme.typography.bodyMedium
-				)
-				Spacer(modifier = Modifier.weight(1f))
-				TextButton(
-					onClick = { onDeleteAllRecentMealSearches() },
-					contentPadding = PaddingValues(0.dp)
-				) {
-					Text(
-						"모두 삭제하기",
-						style = MaterialTheme.typography.bodySmall,
-						color = Color.Gray
-					)
-				}
-			}
-			HorizontalDivider(
-				modifier = Modifier.padding(vertical = 1.dp),
-				color = Color.Black
-			)
-			LazyColumn {
-				items(searches, key = { it.id }) { search ->
-					RecentMedicineSearchItem(
-						search = search,
-						onClick = { onItemClick(search.name) },
-						onDelete = { onItemDelete(search) }
-					)
-				}
-			}
-		}
-	}
+    if (searches.isEmpty()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("최근 검색 기록이 없습니다.", color = Color.Gray)
+        }
+    } else {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "최근 검색",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                TextButton(
+                    onClick = { onDeleteAllRecentMealSearches() },
+                    contentPadding = PaddingValues(0.dp)
+                ) {
+                    Text(
+                        "모두 삭제하기",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.Gray
+                    )
+                }
+            }
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 1.dp),
+                color = Color.Black
+            )
+            LazyColumn {
+                items(searches, key = { it.id }) { search ->
+                    RecentMedicineSearchItem(
+                        search = search,
+                        onClick = { onItemClick(search.name) },
+                        onDelete = { onItemDelete(search) }
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Composable
 private fun RecentMedicineSearchItem(
-	search: RecentMealSearch,
-	onClick: () -> Unit,
-	onDelete: () -> Unit
+    search: RecentMealSearch,
+    onClick: () -> Unit,
+    onDelete: () -> Unit
 ) {
-	Row(
-		modifier = Modifier
-			.fillMaxWidth()
-			.clickable(onClick = onClick)
-			.padding(vertical = 12.dp),
-		verticalAlignment = Alignment.CenterVertically
-	) {
-		Icon(
-			imageVector = Icons.Default.Search,
-			contentDescription = "최근 검색 아이콘",
-			tint = Color.Gray,
-			modifier = Modifier.padding(end = 16.dp)
-		)
-		Text(
-			text = search.name,
-			style = MaterialTheme.typography.bodyLarge,
-			modifier = Modifier.weight(1f)
-		)
-		IconButton(onClick = onDelete, modifier = Modifier.size(24.dp)) {
-			Icon(
-				imageVector = Icons.Default.Close,
-				contentDescription = "기록 삭제",
-				tint = Color.Gray
-			)
-		}
-	}
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Default.Search,
+            contentDescription = "최근 검색 아이콘",
+            tint = Color.Gray,
+            modifier = Modifier.padding(end = 16.dp)
+        )
+        Text(
+            text = search.name,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f)
+        )
+        IconButton(onClick = onDelete, modifier = Modifier.size(24.dp)) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "기록 삭제",
+                tint = Color.Gray
+            )
+        }
+    }
 }

--- a/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/diet/DietSearchScreen.kt
+++ b/features/carefullcontents/src/main/java/com/cases/carefull/features/carefullcontents/routine/diet/DietSearchScreen.kt
@@ -17,8 +17,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
@@ -33,7 +31,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -47,10 +44,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -64,6 +59,7 @@ import com.cases.carefull.features.carefullcommon.R
 import com.cases.carefull.features.carefullcommon.components.CommonAlertDialog
 import com.cases.carefull.features.carefullcommon.components.CommonNumberOutLinedTextField
 import com.cases.carefull.features.carefullcommon.components.CommonTextOutLinedTextField
+import com.cases.carefull.features.carefullcommon.components.SearchBar
 import com.cases.carefull.features.carefullcommon.navigation.RoutineRoute
 import java.time.LocalDate
 
@@ -81,7 +77,6 @@ fun DietSearchScreen(
     }
 
     var foodToEdit by remember { mutableStateOf<DietCollection?>(null) }
-    var showDirectInputDialog by remember { mutableStateOf(false) }
     val searchQuery by viewModel.searchQuery.collectAsState()
 
     if (mealType == null || selectedDate == null) {
@@ -182,13 +177,17 @@ fun DietSearchScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             SearchBar(
-                value = searchQuery,
-                onValueChange = { newQuery ->
+                modifier = Modifier,
+                query = searchQuery,
+                onQueryChange = { newQuery ->
                     viewModel.onSearchQueryChanged(newQuery)
                 },
-                onSearch = { viewModel.onRecentMealSearch() }
+                onSearch = { viewModel.onRecentMealSearch() },
+                placeholder = "음식을 검색하세요",
             )
+
             Spacer(Modifier.height(16.dp))
+
             Row(modifier = Modifier.fillMaxWidth()) {
                 OutlinedButton(
                     onClick = { viewModel.showFavoritesDialog() },
@@ -413,64 +412,6 @@ fun CustomInputAlertDialog(
             }
         }
     )
-}
-
-@Composable
-fun SearchBar(
-    value: String,
-    onValueChange: (String) -> Unit,
-    onSearch: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val keyboardController = LocalSoftwareKeyboardController.current
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        OutlinedTextField(
-            value = value,
-            onValueChange = onValueChange,
-            textStyle = MaterialTheme.typography.bodyLarge,
-            label = { Text(stringResource(R.string.food_search_title)) },
-            modifier = Modifier.weight(1f),
-            singleLine = true,
-            placeholder = { Text(stringResource(R.string.food_search_hint)) },
-//			leadingIcon = {
-//				Icon(
-//					imageVector = Icons.Default.Search,
-//					contentDescription = "검색 아이콘"
-//				)
-//			},
-            trailingIcon = {
-                if (value.isNotBlank()) {
-                    IconButton(onClick = { onValueChange("") }) {
-                        Icon(
-                            imageVector = Icons.Default.Close,
-                            contentDescription = stringResource(R.string.common_clear_input)
-                        )
-                    }
-                }
-            },
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-            keyboardActions = KeyboardActions(onSearch = {
-                onSearch()
-                keyboardController?.hide()
-            }
-            ),
-            shape = RoundedCornerShape(16.dp)
-        )
-        IconButton(
-            modifier = Modifier.padding(top = 10.dp),
-            onClick = {
-                onSearch()
-                keyboardController?.hide()
-            }) {
-            Icon(
-                imageVector = Icons.Default.Search,
-                contentDescription = stringResource(R.string.content_description_search_icon)
-            )
-        }
-    }
 }
 
 


### PR DESCRIPTION
📝 작업 내용
---
- 검색바 공용 컴포넌트 및 미리보기 구현

📑 상세 설명 
---
- 챗봇,질환,약,음식 검색창 통일
- 여러 케이스의 미리보기 구현

🗞️ 기타
---
- 이전 검색바 구현 코드는 주석처리 하였습니다.
- HospitalSearchScreen에도 동일한 검색창 구현 후 주석처리하여 이전 검색창과 비교 바랍니다.
